### PR TITLE
Added panic to fitting NewCommand functions

### DIFF
--- a/cmd/devguard-scanner/commands/attest.go
+++ b/cmd/devguard-scanner/commands/attest.go
@@ -81,6 +81,7 @@ func NewAttestCommand() *cobra.Command {
 			err := attestCmd(cmd, args)
 			if err != nil {
 				slog.Error("attestation failed", "err", err)
+				panic(err.Error())
 			}
 		},
 	}

--- a/cmd/devguard-scanner/commands/container-scanning.go
+++ b/cmd/devguard-scanner/commands/container-scanning.go
@@ -45,7 +45,8 @@ func NewContainerScanningCommand() *cobra.Command {
 
 			if err != nil {
 				slog.Error("container scanning failed", "err", err)
-				return
+				panic(err.Error())
+
 			}
 		},
 	}

--- a/cmd/devguard-scanner/commands/healthcheck.go
+++ b/cmd/devguard-scanner/commands/healthcheck.go
@@ -42,7 +42,7 @@ func NewHealthCheckCommand() *cobra.Command {
 				err := cmd.Run()
 				if err != nil {
 					slog.Error("could not execute command", "command", command, "err", err)
-					return
+					panic(err.Error())
 				}
 				// read the output
 				slog.Info("command executed successfully", "command", command)


### PR DESCRIPTION
I did not add panic if: 
1. There is no error returned in any function of the packet
2. Login so the server doesn't crash?
3. Sign Command because we already have os.Exit