### PR TITLE
356 only automatically create tickets if there is no other asset version with an already created ticket for this vulnerability

### DIFF
--- a/internal/core/dependency_vuln/dependency_vuln_service.go
+++ b/internal/core/dependency_vuln/dependency_vuln_service.go
@@ -342,7 +342,6 @@ func (s *service) CreateIssuesForVulns(asset models.Asset, vulnList []models.Dep
 
 // function to remove duplicate code from the different cases of the createIssuesForVulns function
 func (s *service) createIssue(cveName string, asset models.Asset, repoId string, orgSlug string, projectSlug string) error {
-	//Check if the cve was already found in this asset
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/internal/core/dependency_vuln/dependency_vuln_service.go
+++ b/internal/core/dependency_vuln/dependency_vuln_service.go
@@ -342,6 +342,8 @@ func (s *service) CreateIssuesForVulns(asset models.Asset, vulnList []models.Dep
 
 // function to remove duplicate code from the different cases of the createIssuesForVulns function
 func (s *service) createIssue(cveName string, asset models.Asset, repoId string, orgSlug string, projectSlug string) error {
+	//Check if the cve was already found in this asset
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/internal/core/vulndb/scan/scan_controller.go
+++ b/internal/core/vulndb/scan/scan_controller.go
@@ -133,9 +133,11 @@ func DependencyVulnScan(c core.Context, bom normalize.SBOM, s *httpController) (
 		return scanResults, err
 	}
 
-	err = s.dependencyVulnService.CreateIssuesForVulns(asset, newState)
-	if err != nil {
-		return scanResults, err
+	if assetVersion.DefaultBranch {
+		err = s.dependencyVulnService.CreateIssuesForVulns(asset, newState)
+		if err != nil {
+			return scanResults, err
+		}
 	}
 
 	if doRiskManagement {

--- a/internal/core/vulndb/scan/scan_controller.go
+++ b/internal/core/vulndb/scan/scan_controller.go
@@ -134,7 +134,7 @@ func DependencyVulnScan(c core.Context, bom normalize.SBOM, s *httpController) (
 	}
 
 	//Only create Tickets if the assetVersion is the default assetVersion
-	err = ShouldCreateIssue(s, asset, assetVersion, newState)
+	err = shouldCreateIssue(s, asset, assetVersion, newState)
 	if err != nil {
 		return scanResults, err
 	}
@@ -159,7 +159,7 @@ func DependencyVulnScan(c core.Context, bom normalize.SBOM, s *httpController) (
 	return scanResults, nil
 }
 
-func ShouldCreateIssue(s *httpController, asset models.Asset, assetVersion models.AssetVersion, newState []models.DependencyVuln) error {
+func shouldCreateIssue(s *httpController, asset models.Asset, assetVersion models.AssetVersion, newState []models.DependencyVuln) error {
 	//if the vulnerability was found anywhere else than the default branch we don't want to create an issue
 	if assetVersion.DefaultBranch {
 		err := s.dependencyVulnService.CreateIssuesForVulns(asset, newState)

--- a/internal/core/vulndb/scan/scan_controller.go
+++ b/internal/core/vulndb/scan/scan_controller.go
@@ -160,6 +160,7 @@ func DependencyVulnScan(c core.Context, bom normalize.SBOM, s *httpController) (
 }
 
 func ShouldCreateIssue(s *httpController, asset models.Asset, assetVersion models.AssetVersion, newState []models.DependencyVuln) error {
+	//if the vulnerability was found anywhere else than the default branch we don't want to create an issue
 	if assetVersion.DefaultBranch {
 		err := s.dependencyVulnService.CreateIssuesForVulns(asset, newState)
 		if err != nil {

--- a/internal/core/vulndb/scan/scan_controller.go
+++ b/internal/core/vulndb/scan/scan_controller.go
@@ -133,11 +133,10 @@ func DependencyVulnScan(c core.Context, bom normalize.SBOM, s *httpController) (
 		return scanResults, err
 	}
 
-	if assetVersion.DefaultBranch {
-		err = s.dependencyVulnService.CreateIssuesForVulns(asset, newState)
-		if err != nil {
-			return scanResults, err
-		}
+	//Only create Tickets if the assetVersion is the default assetVersion
+	err = ShouldCreateIssue(s, asset, assetVersion, newState)
+	if err != nil {
+		return scanResults, err
 	}
 
 	if doRiskManagement {
@@ -158,6 +157,16 @@ func DependencyVulnScan(c core.Context, bom normalize.SBOM, s *httpController) (
 	scanResults.DependencyVulns = utils.Map(newState, dependency_vuln.DependencyVulnToDto)
 
 	return scanResults, nil
+}
+
+func ShouldCreateIssue(s *httpController, asset models.Asset, assetVersion models.AssetVersion, newState []models.DependencyVuln) error {
+	if assetVersion.DefaultBranch {
+		err := s.dependencyVulnService.CreateIssuesForVulns(asset, newState)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *httpController) FirstPartyVulnScan(c core.Context) error {

--- a/internal/core/vulndb/scan/scan_test.go
+++ b/internal/core/vulndb/scan/scan_test.go
@@ -1,0 +1,57 @@
+package scan
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/l3montree-dev/devguard/internal/database/models"
+	"github.com/l3montree-dev/devguard/mocks"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestShouldCreateIssue(t *testing.T) {
+	t.Run("Function should return nil if we are not on the default branch", func(t *testing.T) {
+		assetVersion := models.AssetVersion{
+			DefaultBranch: false,
+		}
+		asset := models.Asset{}
+		err := ShouldCreateIssue(nil, asset, assetVersion, nil)
+		if err != nil {
+			t.Fail()
+		}
+	})
+	t.Run("Function should return nil if we successfully create an issue", func(t *testing.T) {
+		assetVersion := models.AssetVersion{
+			DefaultBranch: true,
+		}
+		asset := models.Asset{}
+		vulns := []models.DependencyVuln{}
+
+		dependencyVulnRepositoryMock := mocks.NewCoreDependencyVulnService(t)
+		dependencyVulnRepositoryMock.On("CreateIssuesForVulns", mock.Anything, mock.Anything).Return(nil)
+
+		controller := NewHttpController(nil, nil, nil, nil, nil, nil, nil, dependencyVulnRepositoryMock)
+
+		err := ShouldCreateIssue(controller, asset, assetVersion, vulns)
+		if err != nil {
+			t.Fail()
+		}
+	})
+	t.Run("Function should return an error if we run into problems when creating the issue", func(t *testing.T) {
+		assetVersion := models.AssetVersion{
+			DefaultBranch: true,
+		}
+		asset := models.Asset{}
+		vulns := []models.DependencyVuln{}
+
+		dependencyVulnRepositoryMock := mocks.NewCoreDependencyVulnService(t)
+		dependencyVulnRepositoryMock.On("CreateIssuesForVulns", mock.Anything, mock.Anything).Return(fmt.Errorf("Something went wrong when creating the Issue"))
+
+		controller := NewHttpController(nil, nil, nil, nil, nil, nil, nil, dependencyVulnRepositoryMock)
+
+		err := ShouldCreateIssue(controller, asset, assetVersion, vulns)
+		if err == nil {
+			t.Fail()
+		}
+	})
+}

--- a/internal/core/vulndb/scan/scan_test.go
+++ b/internal/core/vulndb/scan/scan_test.go
@@ -15,7 +15,7 @@ func TestShouldCreateIssue(t *testing.T) {
 			DefaultBranch: false,
 		}
 		asset := models.Asset{}
-		err := ShouldCreateIssue(nil, asset, assetVersion, nil)
+		err := shouldCreateIssue(nil, asset, assetVersion, nil)
 		if err != nil {
 			t.Fail()
 		}
@@ -32,7 +32,7 @@ func TestShouldCreateIssue(t *testing.T) {
 
 		controller := NewHttpController(nil, nil, nil, nil, nil, nil, nil, dependencyVulnRepositoryMock)
 
-		err := ShouldCreateIssue(controller, asset, assetVersion, vulns)
+		err := shouldCreateIssue(controller, asset, assetVersion, vulns)
 		if err != nil {
 			t.Fail()
 		}
@@ -49,7 +49,7 @@ func TestShouldCreateIssue(t *testing.T) {
 
 		controller := NewHttpController(nil, nil, nil, nil, nil, nil, nil, dependencyVulnRepositoryMock)
 
-		err := ShouldCreateIssue(controller, asset, assetVersion, vulns)
+		err := shouldCreateIssue(controller, asset, assetVersion, vulns)
 		if err == nil {
 			t.Fail()
 		}

--- a/internal/core/vulndb/scan/scan_test.go
+++ b/internal/core/vulndb/scan/scan_test.go
@@ -1,57 +1,31 @@
 package scan
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/l3montree-dev/devguard/internal/database/models"
-	"github.com/l3montree-dev/devguard/mocks"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestShouldCreateIssue(t *testing.T) {
-	t.Run("Function should return nil if we are not on the default branch", func(t *testing.T) {
+	t.Run("Function should return false if the assetVersion is the default branch", func(t *testing.T) {
 		assetVersion := models.AssetVersion{
 			DefaultBranch: false,
 		}
-		asset := models.Asset{}
-		err := shouldCreateIssue(nil, asset, assetVersion, nil)
-		if err != nil {
+
+		defaultBranch := shouldCreateIssue(assetVersion)
+		if defaultBranch {
 			t.Fail()
 		}
 	})
-	t.Run("Function should return nil if we successfully create an issue", func(t *testing.T) {
+	t.Run("Function should return true if the assetVersion is the default branch", func(t *testing.T) {
 		assetVersion := models.AssetVersion{
 			DefaultBranch: true,
 		}
-		asset := models.Asset{}
-		vulns := []models.DependencyVuln{}
 
-		dependencyVulnRepositoryMock := mocks.NewCoreDependencyVulnService(t)
-		dependencyVulnRepositoryMock.On("CreateIssuesForVulns", mock.Anything, mock.Anything).Return(nil)
-
-		controller := NewHttpController(nil, nil, nil, nil, nil, nil, nil, dependencyVulnRepositoryMock)
-
-		err := shouldCreateIssue(controller, asset, assetVersion, vulns)
-		if err != nil {
+		defaultBranch := shouldCreateIssue(assetVersion)
+		if !defaultBranch {
 			t.Fail()
 		}
 	})
-	t.Run("Function should return an error if we run into problems when creating the issue", func(t *testing.T) {
-		assetVersion := models.AssetVersion{
-			DefaultBranch: true,
-		}
-		asset := models.Asset{}
-		vulns := []models.DependencyVuln{}
 
-		dependencyVulnRepositoryMock := mocks.NewCoreDependencyVulnService(t)
-		dependencyVulnRepositoryMock.On("CreateIssuesForVulns", mock.Anything, mock.Anything).Return(fmt.Errorf("Something went wrong when creating the Issue"))
-
-		controller := NewHttpController(nil, nil, nil, nil, nil, nil, nil, dependencyVulnRepositoryMock)
-
-		err := shouldCreateIssue(controller, asset, assetVersion, vulns)
-		if err == nil {
-			t.Fail()
-		}
-	})
 }


### PR DESCRIPTION
Added logic to create an issue for a given vulnerability only if it was found on the default branch, sourced it out into its own function and wrote a adequate tests for it.