### PR TITLE
387 Updated Ticket Title Format to Include CVE-ID and Package Name

### DIFF
--- a/internal/core/integrations/github_integration.go
+++ b/internal/core/integrations/github_integration.go
@@ -637,7 +637,7 @@ func (g *githubIntegration) CreateIssue(ctx context.Context, asset models.Asset,
 	assetSlug := asset.Slug
 
 	issue := &github.IssueRequest{
-		Title:  dependencyVuln.CVEID,
+		Title:  github.String(fmt.Sprintf("%s found in %s", utils.SafeDereference(dependencyVuln.CVEID), utils.SafeDereference(dependencyVuln.ComponentPurl))),
 		Body:   github.String(exp.Markdown(g.frontendUrl, orgSlug, projectSlug, assetSlug, assetVersionName) + "\n\n------\n\n" + "Risk exceeds predefined threshold"),
 		Labels: &[]string{"devguard", "severity:" + strings.ToLower(risk.RiskToSeverity(*dependencyVuln.RawRiskAssessment))},
 	}

--- a/internal/core/integrations/gitlab_integration.go
+++ b/internal/core/integrations/gitlab_integration.go
@@ -1074,7 +1074,7 @@ func (g *gitlabIntegration) CreateIssue(ctx context.Context, asset models.Asset,
 	}
 
 	issue := &gitlab.CreateIssueOptions{
-		Title:       gitlab.Ptr(fmt.Sprintf("DependencyVuln %s", dependencyVuln.CVE.CVE)),
+		Title:       gitlab.Ptr(fmt.Sprintf("%s found in %s", utils.SafeDereference(dependencyVuln.CVEID), utils.SafeDereference(dependencyVuln.ComponentPurl))),
 		Description: gitlab.Ptr(exp.Markdown(g.frontendUrl, orgSlug, projectSlug, assetSlug, assetVersionName) + "\n\n------\n\n" + "Risk exceeds predefined threshold"),
 		Labels:      gitlab.Ptr(gitlab.LabelOptions(labels)),
 	}


### PR DESCRIPTION

This pull request improves ticket titles by including both the CVE-ID and the affected package name. Previously, tickets were created with only the CVE-ID

- Updated the ticket title format to:  
  ```plaintext
  CVE-2024-9143 found in <PACKAGE NAME>
  ```
- Applied changes to the following files:  
  - `github_integration.go`  
  - `gitlab_integration.go`  
