### PR TITLE
336 fixed output links in the table

### DIFF
--- a/cmd/devguard-scanner/commands/sca.go
+++ b/cmd/devguard-scanner/commands/sca.go
@@ -262,7 +262,7 @@ func printScaResults(scanResponse scan.ScanResponse, failOnRisk, assetName, webU
 			clickableLink := ""
 			if doRiskManagement {
 				//TODO: change flaws
-				clickableLink = fmt.Sprintf("%s/%s/flaws/%s", webUI, assetName, v.ID)
+				clickableLink = fmt.Sprintf("%s/%s/refs/%s/flaws/%s", webUI, assetName, v.AssetVersionName, v.ID)
 			} else {
 				clickableLink = "Risk Management is disabled"
 			}


### PR DESCRIPTION
This PR fixes the issue where asset version names were missing in the generated URLs in tables. The update ensures that asset version names are properly included table ouput urls.

[Issue 336](https://github.com/l3montree-dev/devguard/issues/336)