### PR TITLE
#444 docker-compose-try.yaml for Easy Testing

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -18,31 +18,31 @@ packages:
     config:
       recursive: true
       all: true
-      filename: "mock_{{.PackageName}}_{{.InterfaceName}}.go"
-      mockName: "{{.PackageName | firstUpper}}{{.InterfaceName | firstUpper}}"
+      filename: "mock_{{.InterfaceName}}.go"
+      mockName: "{{.InterfaceName | firstUpper}}"
       outpkg: "mocks"
       dir: "mocks"
   github.com/l3montree-dev/devguard/internal/accesscontrol:
     config:
       recursive: true
       all: true
-      filename: "mock_{{.PackageName}}_{{.InterfaceName}}.go"
-      mockName: "{{.PackageName | firstUpper}}{{.InterfaceName | firstUpper}}"
+      filename: "mock_{{.InterfaceName}}.go"
+      mockName: "{{.InterfaceName | firstUpper}}"
       outpkg: "mocks"
       dir: "mocks"
   github.com/l3montree-dev/devguard/cmd/devguard/api:
     config:
       recursive: true
       all: true
-      filename: "mock_{{.PackageName}}_{{.InterfaceName}}.go"
-      mockName: "{{.PackageName | firstUpper}}{{.InterfaceName | firstUpper}}"
+      filename: "mock_{{.InterfaceName}}.go"
+      mockName: "{{.InterfaceName | firstUpper}}"
       outpkg: "mocks"
       dir: "mocks"
   github.com/l3montree-dev/devguard/internal/utils:
     config:
       recursive: true
       all: true
-      filename: "mock_{{.PackageName}}_{{.InterfaceName}}.go"
-      mockName: "{{.PackageName | firstUpper}}{{.InterfaceName | firstUpper}}"
+      filename: "mock_{{.InterfaceName}}.go"
+      mockName: "{{.InterfaceName | firstUpper}}"
       outpkg: "mocks"
       dir: "mocks"

--- a/docker-compose-try-it.yaml
+++ b/docker-compose-try-it.yaml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+  postgresql:
+    image: ghcr.io/l3montree-dev/devguard-postgresql:v0.4.16
+    container_name: devguard-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: devguard
+    ports:
+      - "5432:5432"
+
+  kratos:
+    image: oryd/kratos:v1.3.1
+    container_name: devguard-kratos
+    depends_on:
+      - postgresql
+    ports:
+      - "4433:4433"  # Public
+      - "4434:4434"  # Admin
+    environment:
+      - DSN=postgres://kratos:secret@postgresql:5432/kratos?sslmode=disable
+      - LOG_LEVEL=debug
+    command: serve --dev --watch-courier
+
+  devguard-api:
+    image: ghcr.io/l3montree-dev/devguard:latest
+    container_name: devguard-api
+    depends_on:
+      - postgresql
+      - kratos
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgresql://postgres:password@postgresql:5432/devguard
+      - KRATOS_PUBLIC_URL=http://kratos:4433
+      - KRATOS_ADMIN_URL=http://kratos:4434
+      - LOG_LEVEL=debug


### PR DESCRIPTION
This PR introduces a new file: docker-compose-try-it.yaml, which allows users to spin up a fully functional DevGuard instance with a single command—no repo cloning, .env setup, or local dependencies require

As requested in [Issue #444](https://github.com/l3montree-dev/devguard/issues/444), this PR makes it easy for developers and contributors to quickly try out DevGuard using Docker, without any complex setup. It's ideal for demos, testing, or first-time users exploring the platform.

To run:

`curl -LO https://raw.githubusercontent.com/l3montree-dev/devguard/main/docker-compose-try-it.yaml`
`docker-compose -f docker-compose-try-it.yaml up`
 OR 

`curl -LO https://raw.githubusercontent.com/l3montree-dev/devguard/main/docker-compose-try-it.yaml && docker-compose -f docker-compose-try-it.yaml up`