### PR TITLE
fixed mockery.xaml by removing invalid keys

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -12,37 +12,28 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-with-expecter: true
 packages:
   github.com/l3montree-dev/devguard/internal/core:
     config:
       recursive: true
       all: true
       filename: "mock_{{.InterfaceName}}.go"
-      mockName: "{{.InterfaceName | firstUpper}}"
-      outpkg: "mocks"
       dir: "mocks"
   github.com/l3montree-dev/devguard/internal/accesscontrol:
     config:
       recursive: true
       all: true
       filename: "mock_{{.InterfaceName}}.go"
-      mockName: "{{.InterfaceName | firstUpper}}"
-      outpkg: "mocks"
       dir: "mocks"
   github.com/l3montree-dev/devguard/cmd/devguard/api:
     config:
       recursive: true
       all: true
       filename: "mock_{{.InterfaceName}}.go"
-      mockName: "{{.InterfaceName | firstUpper}}"
-      outpkg: "mocks"
       dir: "mocks"
   github.com/l3montree-dev/devguard/internal/utils:
     config:
       recursive: true
       all: true
       filename: "mock_{{.InterfaceName}}.go"
-      mockName: "{{.InterfaceName | firstUpper}}"
-      outpkg: "mocks"
       dir: "mocks"


### PR DESCRIPTION
removed invalid keys from the mockery.yaml file, now `make mocks`works again
