### PR TITLE
set default value for webhookSecret

### DIFF
--- a/internal/core/integrations/gitlabint/gitlab_webhook.go
+++ b/internal/core/integrations/gitlabint/gitlab_webhook.go
@@ -19,11 +19,14 @@ func (g *GitlabIntegration) checkWebhookSecretToken(gitlabSecretToken string, as
 		return err
 	}
 
-	if asset.WebhookSecret != nil {
-		if asset.WebhookSecret.String() != gitlabSecretToken {
-			slog.Error("invalid webhook secret")
-			return errors.New("invalid webhook secret")
-		}
+	if asset.WebhookSecret == nil {
+		slog.Error("webhook secret is not set for asset", "assetID", asset.ID)
+		return errors.New("webhook secret is not set for asset")
+	}
+
+	if asset.WebhookSecret.String() != gitlabSecretToken {
+		slog.Error("invalid webhook secret")
+		return errors.New("invalid webhook secret")
 	}
 
 	return nil

--- a/internal/database/models/asset_model.go
+++ b/internal/database/models/asset_model.go
@@ -55,7 +55,7 @@ type Asset struct {
 	ConfigFiles database.JSONB `json:"configFiles" gorm:"type:jsonb"`
 
 	BadgeSecret   *uuid.UUID `json:"badgeSecret" gorm:"type:uuid;default:gen_random_uuid();"`
-	WebhookSecret *uuid.UUID `json:"webhookSecret" gorm:"type:uuid;"`
+	WebhookSecret *uuid.UUID `json:"webhookSecret" gorm:"type:uuid;default:gen_random_uuid();"`
 
 	ExternalEntityID         *string `json:"externalEntityId" gorm:"uniqueIndex:asset_unique_external_entity;type:text"`
 	ExternalEntityProviderID *string `json:"externalEntityProviderId" gorm:"uniqueIndex:asset_unique_external_entity;type:text"`


### PR DESCRIPTION
Before merging this into main, we need to ensure that all already configured webhooks have the webhook secret, otherwise the sync will not work correctly.

related: https://github.com/l3montree-dev/devguard-web/pull/476