### PR TITLE
Fix scanner to return 400 Bad Request for invalid SBOM uploads

### DIFF
--- a/internal/core/vulndb/scan/scan_controller.go
+++ b/internal/core/vulndb/scan/scan_controller.go
@@ -364,7 +364,7 @@ func (s *HTTPController) ScanDependencyVulnFromProject(c core.Context) error {
 	decoder := cdx.NewBOMDecoder(c.Request().Body, cdx.BOMFileFormatJSON)
 	defer c.Request().Body.Close()
 	if err := decoder.Decode(bom); err != nil {
-		return err
+		return echo.NewHTTPError(400, "Invalid SBOM format").WithInternal(err)
 	}
 
 	scanResults, err := s.DependencyVulnScan(c, normalize.FromCdxBom(bom, true))
@@ -392,7 +392,7 @@ func (s *HTTPController) ScanSbomFile(c core.Context) error {
 	bom := new(cdx.BOM)
 	decoder := cdx.NewBOMDecoder(file, cdx.BOMFileFormatJSON)
 	if err := decoder.Decode(bom); err != nil {
-		return err
+		return echo.NewHTTPError(400, "Invalid SBOM format").WithInternal(err)
 	}
 
 	scanResults, err := s.DependencyVulnScan(c, normalize.FromCdxBom(bom, true))


### PR DESCRIPTION
This fixes issue #1278 where the scanner was returning 500 errors for invalid SBOMs instead of 400. Now it properly sends a 400 Bad Request with a clear message.

## What changed
- In scan_controller.go, wrapped the CycloneDX decoding errors in echo.NewHTTPError(400, "Invalid SBOM format") for both ScanDependencyVulnFromProject and ScanSbomFile methods.
- This matches how other similar errors are handled in the codebase, like in UploadVEX.

## Why this matters
- Users uploading bad SBOMs will now get a proper 400 error instead of a 500, and the client prints the server message so they know what went wrong.
- No breaking changes, just better error handling.

Closes #1278