### PR TITLE
use read recursive to read all releases

### DIFF
--- a/internal/core/release/release_controller.go
+++ b/internal/core/release/release_controller.go
@@ -245,7 +245,7 @@ func (h *releaseController) Read(c core.Context) error {
 		return echo.NewHTTPError(400, "invalid release id")
 	}
 
-	rel, err := h.service.Read(id)
+	rel, err := h.service.ReadRecursive(id)
 	if err != nil {
 		return echo.NewHTTPError(404, "release not found").WithInternal(err)
 	}


### PR DESCRIPTION
required for https://github.com/l3montree-dev/devguard-web/pull/566 because otherwise the `ReleaseDTO` object will not contain any information about children.