### PR TITLE
changed sbom generation to be sound with the spdx standard

### DIFF
--- a/internal/core/normalize/cdx_bom.go
+++ b/internal/core/normalize/cdx_bom.go
@@ -679,6 +679,7 @@ func FromNormalizedCdxBom(bom *cdx.BOM, artifactName string) *CdxBom {
 		BOMRef:     artifactName,
 		Name:       artifactName,
 		PackageURL: artifactName,
+		Type:       "application",
 	})
 
 	cdxBom.ReplaceRoot(newRoot)


### PR DESCRIPTION
SBOM was not sound with SPDX V1.6 standard due to:
- Metadata/Component/Type not set -> now its "application"
- License not properly handled:
      - if we have an unknown or non-standard license write them into the name attribute instead of id attribute
      - if we have a license expression ( containing AND,OR,WITH), write the expression into the expression attribute
      

Open Questions:
Metadata/Component/Type is now set in normalize.FromNormalizedCdxBom which is also used by VEX.json.
Does it make sense to change the value in the normalize function or rather in the calling function AND
is application the fitting type here?

List of valid values for Metadata/Component/Type:
<img width="480" height="413" alt="image" src="https://github.com/user-attachments/assets/6132518c-158a-4f9a-871e-4a30197f1221" />
