### PR TITLE
sbom to pdf crashed becuase of a nil pointer, instead of now giving t…

### DIFF
--- a/services/asset_version_service.go
+++ b/services/asset_version_service.go
@@ -1157,7 +1157,7 @@ func MarkdownTableFromSBOM(outputFile *bytes.Buffer, bom *cdx.BOM) error {
 			}
 		}
 		if len(licenseIDs) == 0 {
-			licenseIDs = []string{"Unknown"}
+			licenseIDs = []string{" Unknown"}
 		}
 
 		templateValues = append(templateValues, componentData{


### PR DESCRIPTION
…he licenses via the pointer we are now using string slices, if there is no license or string then we will set that to unknown, now len.license will always have a valide slice to point to and not a potential nil-pointer anymore