### PR TITLE
adds support for rendering single node paths in Mermaid diagrams

### DIFF
--- a/integrations/commonint/integration_helper.go
+++ b/integrations/commonint/integration_helper.go
@@ -377,20 +377,21 @@ func pathsToMermaid(paths [][]string) string {
 	var existingPaths = make(map[string]bool)
 
 	for _, path := range paths {
-		if len(path) == 1 {
-			// single node path, just add the node
-			nodeID := escapeNodeID(path[0])
-			nodeLabel := beautifyNodeLabel(path[0])
-			mermaidNode := fmt.Sprintf("%s([\"%s\"])\n", nodeID, nodeLabel)
-			if existingPaths[mermaidNode] {
-				// skip if node already exists
+
+		if len(path) > 0 {
+			fromLabel := "Your application"
+			toLabel := path[0]
+			mermaidPath := fmt.Sprintf("%s([\"%s\"]) --- %s([\"%s\"])\n",
+				"Your_application", fromLabel, escapeNodeID(toLabel), beautifyNodeLabel(toLabel))
+			if existingPaths[mermaidPath] {
+				// skip if path already exists
 				continue
 			}
-			existingPaths[mermaidNode] = true
+			existingPaths[mermaidPath] = true
 
-			builder.WriteString(mermaidNode)
-			continue
+			builder.WriteString(mermaidPath)
 		}
+
 		for i := 0; i < len(path)-1; i++ {
 			fromLabel := path[i]
 			toLabel := path[i+1]

--- a/integrations/commonint/integration_helper_test.go
+++ b/integrations/commonint/integration_helper_test.go
@@ -73,7 +73,7 @@ func TestRenderPathToComponent(t *testing.T) {
 
 		// FindAllComponentOnlyPathsToPURL only returns component-only paths (nodes starting with pkg:)
 		// The path should be: root-dep -> test-package
-		assert.Equal(t, "```mermaid \n %%{init: { 'theme':'base', 'themeVariables': {\n'primaryColor': '#F3F3F3',\n'primaryTextColor': '#0D1117',\n'primaryBorderColor': '#999999',\n'lineColor': '#999999',\n'secondaryColor': '#ffffff',\n'tertiaryColor': '#ffffff'\n} }}%%\n flowchart TD\npkg_npm_root_dep_1_0_0([\"pkg:npm/root-dep\\@1.0.0\"]) --- pkg_npm_test_package_1_0_0([\"pkg:npm/test-package\\@1.0.0\"])\n\nclassDef default stroke-width:2px\n```\n", result)
+		assert.Equal(t, "```mermaid \n %%{init: { 'theme':'base', 'themeVariables': {\n'primaryColor': '#F3F3F3',\n'primaryTextColor': '#0D1117',\n'primaryBorderColor': '#999999',\n'lineColor': '#999999',\n'secondaryColor': '#ffffff',\n'tertiaryColor': '#ffffff'\n} }}%%\n flowchart TD\nYour_application([\"Your application\"]) --- pkg_npm_root_dep_1_0_0([\"pkg:npm/root-dep\\@1.0.0\"])\npkg_npm_root_dep_1_0_0([\"pkg:npm/root-dep\\@1.0.0\"]) --- pkg_npm_test_package_1_0_0([\"pkg:npm/test-package\\@1.0.0\"])\n\nclassDef default stroke-width:2px\n```\n", result)
 
 	})
 	t.Run("should escape @ symbols", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestRenderPathToComponent(t *testing.T) {
 
 		// Verify @ symbols are escaped as \@ in the mermaid output
 		assert.Contains(t, result, "\\@1.0.0")
-		assert.Equal(t, "```mermaid \n %%{init: { 'theme':'base', 'themeVariables': {\n'primaryColor': '#F3F3F3',\n'primaryTextColor': '#0D1117',\n'primaryBorderColor': '#999999',\n'lineColor': '#999999',\n'secondaryColor': '#ffffff',\n'tertiaryColor': '#ffffff'\n} }}%%\n flowchart TD\npkg_npm_root_dep_1_0_0([\"pkg:npm/root-dep\\@1.0.0\"]) --- pkg_npm_test_package_1_0_0([\"pkg:npm/test-package\\@1.0.0\"])\n\nclassDef default stroke-width:2px\n```\n", result)
+		assert.Equal(t, "```mermaid \n %%{init: { 'theme':'base', 'themeVariables': {\n'primaryColor': '#F3F3F3',\n'primaryTextColor': '#0D1117',\n'primaryBorderColor': '#999999',\n'lineColor': '#999999',\n'secondaryColor': '#ffffff',\n'tertiaryColor': '#ffffff'\n} }}%%\n flowchart TD\nYour_application([\"Your application\"]) --- pkg_npm_root_dep_1_0_0([\"pkg:npm/root-dep\\@1.0.0\"])\npkg_npm_root_dep_1_0_0([\"pkg:npm/root-dep\\@1.0.0\"]) --- pkg_npm_test_package_1_0_0([\"pkg:npm/test-package\\@1.0.0\"])\n\nclassDef default stroke-width:2px\n```\n", result)
 
 	})
 
@@ -118,7 +118,7 @@ func TestRenderPathToComponent(t *testing.T) {
 		result, err := RenderPathToComponent(componentRepository, assetID, assetVersionName, pURL)
 		assert.NoError(t, err)
 		// The output should contain the single node mermaid representation
-		assert.Equal(t, "```mermaid \n %%{init: { 'theme':'base', 'themeVariables': {\n'primaryColor': '#F3F3F3',\n'primaryTextColor': '#0D1117',\n'primaryBorderColor': '#999999',\n'lineColor': '#999999',\n'secondaryColor': '#ffffff',\n'tertiaryColor': '#ffffff'\n} }}%%\n flowchart TD\npkg_npm_single_1_0_0([\"pkg:npm/single\\@1.0.0\"])\n\nclassDef default stroke-width:2px\n```\n", result)
+		assert.Equal(t, "```mermaid \n %%{init: { 'theme':'base', 'themeVariables': {\n'primaryColor': '#F3F3F3',\n'primaryTextColor': '#0D1117',\n'primaryBorderColor': '#999999',\n'lineColor': '#999999',\n'secondaryColor': '#ffffff',\n'tertiaryColor': '#ffffff'\n} }}%%\n flowchart TD\nYour_application([\"Your application\"]) --- pkg_npm_single_1_0_0([\"pkg:npm/single\\@1.0.0\"])\n\nclassDef default stroke-width:2px\n```\n", result)
 	})
 }
 func TestGetLabels(t *testing.T) {


### PR DESCRIPTION
<img width="438" height="138" alt="Screenshot 2026-02-25 at 14 16 03" src="https://github.com/user-attachments/assets/3a0252f7-c611-4c0b-b8fe-378c88e81dc8" />
