### PR TITLE
fix(1872): added fix for vex rule not working in case of direct dependancy

### DIFF
--- a/dtos/path_pattern_test.go
+++ b/dtos/path_pattern_test.go
@@ -100,6 +100,9 @@ func TestRootPathPattern(t *testing.T) {
 		{"ROOT matches any path with ROOT at end", PathPattern{normalize.GraphRootNodeID}, []string{"A", "B", normalize.GraphRootNodeID}, true},
 		{"ROOT DOES match path without ROOT", PathPattern{normalize.GraphRootNodeID}, []string{"A", "B", "C"}, true},
 		{"ROOT does not lead to all paths matching", PathPattern{normalize.GraphRootNodeID, "X"}, []string{"A", "B", "C"}, false},
+		// Direct dependency: pattern created from the graph includes ROOT but VulnerabilityPath does not.
+		// ["*", "ROOT", "pkg:..."] must match ["pkg:..."] because ROOT is a wildcard that matches zero elements.
+		{"wildcard ROOT pkg matches direct dependency path", PathPattern{"*", normalize.GraphRootNodeID, "pkg:golang/go-jose@v4"}, []string{"pkg:golang/go-jose@v4"}, true},
 	}
 
 	for _, tt := range tests {

--- a/dtos/path_pattern_test.go
+++ b/dtos/path_pattern_test.go
@@ -34,7 +34,7 @@ func TestIsWildcard(t *testing.T) {
 		{"literal pkg:npm/foo", "pkg:npm/foo@1.0.0", false},
 		{"empty string", "", false},
 		{"triple star", "***", false},
-		{"ROOT is wildcard", normalize.GraphRootNodeID, true},
+		{"ROOT is not a wildcard", normalize.GraphRootNodeID, false},
 	}
 
 	for _, tt := range tests {
@@ -96,12 +96,14 @@ func TestRootPathPattern(t *testing.T) {
 		path     []string
 		expected bool
 	}{
-		{"ROOT matches ROOT", PathPattern{normalize.GraphRootNodeID}, []string{normalize.GraphRootNodeID}, true},
-		{"ROOT matches any path with ROOT at end", PathPattern{normalize.GraphRootNodeID}, []string{"A", "B", normalize.GraphRootNodeID}, true},
-		{"ROOT DOES match path without ROOT", PathPattern{normalize.GraphRootNodeID}, []string{"A", "B", "C"}, true},
-		{"ROOT does not lead to all paths matching", PathPattern{normalize.GraphRootNodeID, "X"}, []string{"A", "B", "C"}, false},
-		// Direct dependency: pattern created from the graph includes ROOT but VulnerabilityPath does not.
-		// ["*", "ROOT", "pkg:..."] must match ["pkg:..."] because ROOT is a wildcard that matches zero elements.
+		// ROOT is a stop marker: [root, pkg:A] matches only direct dependencies.
+		// VulnerabilityPath never contains ROOT, so ROOT in the pattern consumes
+		// zero path elements and anchors the match to position 0 (no suffix scan).
+		{"root pkg:A matches direct dependency", PathPattern{normalize.GraphRootNodeID, "pkg:A"}, []string{"pkg:A"}, true},
+		{"root pkg:A does not match transitive dependency", PathPattern{normalize.GraphRootNodeID, "pkg:A"}, []string{"pkg:B", "pkg:A"}, false},
+		// [*, ROOT, pkg:A] is equivalent to [ROOT, pkg:A]: ROOT absorbs the wildcard prefix.
+		{"wildcard root pkg:A matches direct dependency", PathPattern{"*", normalize.GraphRootNodeID, "pkg:A"}, []string{"pkg:A"}, true},
+		{"wildcard root pkg:A does not match transitive dependency", PathPattern{"*", normalize.GraphRootNodeID, "pkg:A"}, []string{"pkg:B", "pkg:A"}, false},
 		{"wildcard ROOT pkg matches direct dependency path", PathPattern{"*", normalize.GraphRootNodeID, "pkg:golang/go-jose@v4"}, []string{"pkg:golang/go-jose@v4"}, true},
 	}
 

--- a/dtos/vex_rule_dto.go
+++ b/dtos/vex_rule_dto.go
@@ -98,6 +98,17 @@ func matchPatternExact(pattern, path []string) bool {
 				return true
 			}
 
+			// If the next pattern element is also a wildcard (e.g. ROOT), try
+			// matching it at the current path position (zero-element match for
+			// this wildcard). This handles patterns like ["*", "ROOT", "pkg:..."]
+			// against paths like ["pkg:..."] where ROOT never appears in
+			// component-only vulnerability paths.
+			if IsWildcard(pattern[pIdx+1]) {
+				if matchPatternExact(pattern[pIdx+1:], path[pathIdx:]) {
+					return true
+				}
+			}
+
 			// Try to find the next pattern element in the path
 			nextPattern := pattern[pIdx+1]
 

--- a/dtos/vex_rule_dto.go
+++ b/dtos/vex_rule_dto.go
@@ -37,10 +37,7 @@ type PathPattern []string
 
 // IsWildcard returns true if the element is a wildcard (*).
 func IsWildcard(elem string) bool {
-	// ROOT is a special element in the path
-	// this means, THE CURRENT application does not call the vulnerable code
-	// therefore, we can just replace it with a wildcard for matching purposes
-	return elem == PathPatternWildcard || elem == normalize.GraphRootNodeID
+	return elem == PathPatternWildcard
 }
 
 // MatchesSuffix checks if the given path's suffix matches this pattern using suffix matching.
@@ -55,6 +52,14 @@ func (p PathPattern) MatchesSuffix(path []string) bool {
 
 	if len(p) == 0 {
 		return true
+	}
+
+	// ROOT is a stop marker meaning "direct dependency only". When the pattern
+	// contains ROOT, skip suffix scanning and match the full path from position 0.
+	for _, elem := range p {
+		if elem == normalize.GraphRootNodeID {
+			return matchPatternExact(p, path)
+		}
 	}
 
 	// For suffix matching, we try increasingly longer suffixes
@@ -98,12 +103,10 @@ func matchPatternExact(pattern, path []string) bool {
 				return true
 			}
 
-			// If the next pattern element is also a wildcard (e.g. ROOT), try
-			// matching it at the current path position (zero-element match for
-			// this wildcard). This handles patterns like ["*", "ROOT", "pkg:..."]
-			// against paths like ["pkg:..."] where ROOT never appears in
-			// component-only vulnerability paths.
-			if IsWildcard(pattern[pIdx+1]) {
+			// If the next pattern element is ROOT (stop marker), try a zero-length
+			// match for this wildcard. [*, ROOT, pkg:A] is equivalent to [ROOT, pkg:A]:
+			// ROOT anchors the remainder to the current path position.
+			if pattern[pIdx+1] == normalize.GraphRootNodeID {
 				if matchPatternExact(pattern[pIdx+1:], path[pathIdx:]) {
 					return true
 				}
@@ -134,6 +137,13 @@ func matchPatternExact(pattern, path []string) bool {
 				return true
 			}
 			return pathIdx == len(path)
+		}
+
+		// ROOT is a stop marker — it is never stored in VulnerabilityPath,
+		// so skip it in the pattern without consuming a path element.
+		if pattern[pIdx] == normalize.GraphRootNodeID {
+			pIdx++
+			continue
 		}
 
 		// Literal match


### PR DESCRIPTION
 # Title: VEX rules not applied for direct dependencies (https://github.com/l3montree-dev/devguard/issues/1872)

  # Summary:

  Fixed a bug in matchPatternExact where patterns like ["*", "ROOT", "pkg:..."] never matched direct dependency vulnerability paths
  like ["pkg:..."].

  When a wildcard (*) was processing and its next pattern element was also a wildcard (ROOT), the code searched for "ROOT" literally
  in the path. Since ROOT is a structural graph node and never stored in VulnerabilityPath, the match always failed.

  Fix: Before searching for the next pattern element literally, check if it is itself a wildcard. If so, attempt a zero-element match
   by recursing directly — consistent with how IsWildcard already treats ROOT.

  Files changed:
  - `dtos/vex_rule_dto.go` — fixed matchPatternExact to handle consecutive wildcards
  - `dtos/path_pattern_test.go` — added test case for direct dependency matching



Output:

<img width="1892" height="977" alt="Screenshot 2026-04-12 075254" src="https://github.com/user-attachments/assets/1c1e5f15-7285-4118-9d4d-846fa6c37759" />

<img width="1897" height="913" alt="Screenshot 2026-04-12 080003" src="https://github.com/user-attachments/assets/4c615bc7-e852-462d-86b5-68a5cdd75ed8" />

<img width="1879" height="1001" alt="Screenshot 2026-04-12 080307" src="https://github.com/user-attachments/assets/ccb12132-dd1c-4aba-939c-87a9de799a42" />