### PR TITLE
Fixed api returning every VexRule on request

### DIFF
--- a/controllers/vex_rule_controller.go
+++ b/controllers/vex_rule_controller.go
@@ -77,7 +77,7 @@ func (c *VEXRuleController) List(ctx shared.Context) error {
 	asset := shared.GetAsset(ctx)
 	assetVersion := shared.GetAssetVersion(ctx)
 
-	vulnID := ctx.QueryParam("vulnId")
+	vulnID := ctx.QueryParam("dependencyVulnId")
 	if vulnID != "" {
 		vulnIDParsed, err := uuid.Parse(vulnID)
 		if err != nil {


### PR DESCRIPTION
Fixes Issue: https://github.com/l3montree-dev/devguard/issues/1870
Fixed the error that all all VexRules are returned on request to a specific Vuln.

The issue was that there was a mismatch in query parameters. While the frontend was using the query param `dependencyVulnId`, the backend API expected the parameter `vulnId`. It therefore defaulted back into a case where the database would return every VexRule in the organisation for every vuln.

This issue is solved now, but VexRules which contain direct dependencies are still not being displayed. This is discussed in Issue: https://github.com/l3montree-dev/devguard/issues/1872