### PR TITLE
Add admin-only organization settings endpoint

### DIFF
--- a/controllers/org_controller.go
+++ b/controllers/org_controller.go
@@ -445,6 +445,23 @@ func (controller *OrgController) Members(ctx shared.Context) error {
 	return ctx.JSON(200, users)
 }
 
+// @Summary Get organization admin settings
+// @Tags Organizations
+// @Security CookieAuth
+// @Security PATAuth
+// @Param organization path string true "Organization slug"
+// @Success 200 {object} dtos.OrgSettingsDTO
+// @Router /organizations/{organization}/settings [get]
+func (controller *OrgController) AdminSettings(ctx shared.Context) error {
+	organization := shared.GetOrg(ctx)
+	members, err := shared.FetchMembersOfOrganization(ctx)
+	if err != nil {
+		return echo.NewHTTPError(500, "could not get members of organization").WithInternal(err)
+	}
+
+	return ctx.JSON(200, transformer.OrgSettingsDTOFromModel(organization, members))
+}
+
 // @Summary Get organization details
 // @Tags Organizations
 // @Security CookieAuth
@@ -453,6 +470,10 @@ func (controller *OrgController) Members(ctx shared.Context) error {
 // @Success 200 {object} dtos.OrgDetailsDTO
 // @Router /organizations/{organization} [get]
 func (controller *OrgController) Read(ctx shared.Context) error {
+	return controller.readDetails(ctx)
+}
+
+func (controller *OrgController) readDetails(ctx shared.Context) error {
 	// get the organization from the context
 	organization := shared.GetOrg(ctx)
 	// fetch the regular members of the current organization

--- a/controllers/org_controller_test.go
+++ b/controllers/org_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/l3montree-dev/devguard/database/models"
+	"github.com/l3montree-dev/devguard/dtos"
 	"github.com/l3montree-dev/devguard/mocks"
 	"github.com/l3montree-dev/devguard/shared"
 	"github.com/labstack/echo/v4"
@@ -162,6 +164,89 @@ func TestOrgControllerUpdateConfigFile(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, http.StatusInternalServerError, httpErr.Code)
 	})
+}
+
+func TestOrgControllerAdminSettings(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	webhookName := "Alerts"
+	webhookDescription := "Security alerts"
+	org := models.Org{
+		Name: "DevGuard",
+		Slug: "devguard",
+		Webhooks: []models.WebhookIntegration{{
+			Name:        &webhookName,
+			Description: &webhookDescription,
+			URL:         "https://example.com/webhook",
+			SbomEnabled: true,
+			VulnEnabled: true,
+		}},
+	}
+	shared.SetOrg(ctx, org)
+
+	mockRBAC := mocks.NewAccessControl(t)
+	mockRBAC.On("GetAllMembersOfOrganization").Return([]string{}, nil)
+	shared.SetRBAC(ctx, mockRBAC)
+
+	mockIntegrations := mocks.NewIntegrationAggregate(t)
+	mockIntegrations.On("GetUsers", org).Return([]dtos.UserDTO{})
+	shared.SetThirdPartyIntegration(ctx, mockIntegrations)
+
+	controller := &OrgController{}
+	err := controller.AdminSettings(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response dtos.OrgSettingsDTO
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Equal(t, org.Name, response.Name)
+	assert.Equal(t, org.Slug, response.Slug)
+	assert.Empty(t, response.Members)
+	assert.Len(t, response.Webhooks, 1)
+	assert.Equal(t, "https://example.com/webhook", response.Webhooks[0].URL)
+}
+
+func TestOrgControllerReadDoesNotExposeWebhooks(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	webhookName := "Alerts"
+	webhookDescription := "Security alerts"
+	org := models.Org{
+		Name: "DevGuard",
+		Slug: "devguard",
+		Webhooks: []models.WebhookIntegration{{
+			Name:        &webhookName,
+			Description: &webhookDescription,
+			URL:         "https://example.com/webhook",
+		}},
+	}
+	shared.SetOrg(ctx, org)
+
+	mockRBAC := mocks.NewAccessControl(t)
+	mockRBAC.On("GetAllMembersOfOrganization").Return([]string{}, nil)
+	shared.SetRBAC(ctx, mockRBAC)
+
+	mockIntegrations := mocks.NewIntegrationAggregate(t)
+	mockIntegrations.On("GetUsers", org).Return([]dtos.UserDTO{})
+	shared.SetThirdPartyIntegration(ctx, mockIntegrations)
+
+	controller := &OrgController{}
+	err := controller.Read(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Equal(t, org.Name, response["name"])
+	assert.NotContains(t, response, "webhooks")
 }
 
 // Test function for Create and bootstrap from org_controller

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1448,13 +1448,6 @@
                     },
                     "updatedAt": {
                         "type": "string"
-                    },
-                    "webhooks": {
-                        "items": {
-                            "$ref": "#/components/schemas/dtos.WebhookIntegrationDTO"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
                     }
                 },
                 "type": "object"
@@ -1668,6 +1661,111 @@
                     },
                     "mediumCvss": {
                         "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "dtos.OrgSettingsDTO": {
+                "properties": {
+                    "configFiles": {
+                        "additionalProperties": {},
+                        "type": "object"
+                    },
+                    "contactPhoneNumber": {
+                        "type": "string"
+                    },
+                    "country": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "criticalInfrastructure": {
+                        "type": "boolean"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "externalEntityProviderId": {
+                        "type": "string"
+                    },
+                    "gitLabIntegrations": {
+                        "items": {
+                            "$ref": "#/components/schemas/dtos.GitlabIntegrationDTO"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "githubAppInstallations": {
+                        "items": {
+                            "$ref": "#/components/schemas/dtos.GithubAppInstallationDTO"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "grundschutz": {
+                        "type": "boolean"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "industry": {
+                        "type": "string"
+                    },
+                    "isPublic": {
+                        "type": "boolean"
+                    },
+                    "iso27001": {
+                        "type": "boolean"
+                    },
+                    "jiraIntegrations": {
+                        "items": {
+                            "$ref": "#/components/schemas/dtos.JiraIntegrationDTO"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "members": {
+                        "items": {
+                            "$ref": "#/components/schemas/dtos.UserDTO"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "nist": {
+                        "type": "boolean"
+                    },
+                    "numberOfEmployees": {
+                        "type": "integer"
+                    },
+                    "projects": {
+                        "items": {
+                            "$ref": "#/components/schemas/dtos.ProjectDTO"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "sharesVulnInformation": {
+                        "type": "boolean"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    },
+                    "webhooks": {
+                        "items": {
+                            "$ref": "#/components/schemas/dtos.WebhookIntegrationDTO"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
                     }
                 },
                 "type": "object"
@@ -9438,6 +9536,45 @@
                 "summary": "List first-party vulnerabilities by project",
                 "tags": [
                     "Vulnerabilities"
+                ]
+            }
+        },
+        "/organizations/{organization}/settings": {
+            "get": {
+                "parameters": [
+                    {
+                        "description": "Organization slug",
+                        "in": "path",
+                        "name": "organization",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dtos.OrgSettingsDTO"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "security": [
+                    {
+                        "CookieAuth": []
+                    },
+                    {
+                        "PATAuth": []
+                    }
+                ],
+                "summary": "Get organization admin settings",
+                "tags": [
+                    "Organizations"
                 ]
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -981,11 +981,6 @@ components:
           type: string
         updatedAt:
           type: string
-        webhooks:
-          items:
-            $ref: '#/components/schemas/dtos.WebhookIntegrationDTO'
-          type: array
-          uniqueItems: false
       type: object
     dtos.OrgOverview:
       properties:
@@ -1130,6 +1125,78 @@ components:
           type: integer
         mediumCvss:
           type: integer
+      type: object
+    dtos.OrgSettingsDTO:
+      properties:
+        configFiles:
+          additionalProperties: {}
+          type: object
+        contactPhoneNumber:
+          type: string
+        country:
+          type: string
+        createdAt:
+          type: string
+        criticalInfrastructure:
+          type: boolean
+        description:
+          type: string
+        externalEntityProviderId:
+          type: string
+        gitLabIntegrations:
+          items:
+            $ref: '#/components/schemas/dtos.GitlabIntegrationDTO'
+          type: array
+          uniqueItems: false
+        githubAppInstallations:
+          items:
+            $ref: '#/components/schemas/dtos.GithubAppInstallationDTO'
+          type: array
+          uniqueItems: false
+        grundschutz:
+          type: boolean
+        id:
+          type: string
+        industry:
+          type: string
+        isPublic:
+          type: boolean
+        iso27001:
+          type: boolean
+        jiraIntegrations:
+          items:
+            $ref: '#/components/schemas/dtos.JiraIntegrationDTO'
+          type: array
+          uniqueItems: false
+        language:
+          type: string
+        members:
+          items:
+            $ref: '#/components/schemas/dtos.UserDTO'
+          type: array
+          uniqueItems: false
+        name:
+          type: string
+        nist:
+          type: boolean
+        numberOfEmployees:
+          type: integer
+        projects:
+          items:
+            $ref: '#/components/schemas/dtos.ProjectDTO'
+          type: array
+          uniqueItems: false
+        sharesVulnInformation:
+          type: boolean
+        slug:
+          type: string
+        updatedAt:
+          type: string
+        webhooks:
+          items:
+            $ref: '#/components/schemas/dtos.WebhookIntegrationDTO'
+          type: array
+          uniqueItems: false
       type: object
     dtos.OrgStructureDistribution:
       properties:
@@ -6024,6 +6091,28 @@ paths:
       summary: List first-party vulnerabilities by project
       tags:
       - Vulnerabilities
+  /organizations/{organization}/settings:
+    get:
+      parameters:
+      - description: Organization slug
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dtos.OrgSettingsDTO'
+          description: OK
+      security:
+      - CookieAuth: []
+      - PATAuth: []
+      summary: Get organization admin settings
+      tags:
+      - Organizations
   /organizations/{organization}/stats/vuln-statistics/:
     get:
       description: Returns aggregated security statistics for an organization, including

--- a/dtos/org_dto.go
+++ b/dtos/org_dto.go
@@ -98,15 +98,19 @@ type OrgDTO struct {
 
 	JiraIntegrations []JiraIntegrationDTO `json:"jiraIntegrations" gorm:"foreignKey:OrgID;"`
 
-	SharesVulnInformation    bool                    `json:"sharesVulnInformation"`
-	IsPublic                 bool                    `json:"isPublic" gorm:"default:false;"`
-	Webhooks                 []WebhookIntegrationDTO `json:"webhooks" gorm:"foreignKey:OrgID;"`
-	ConfigFiles              map[string]any          `json:"configFiles"`
-	Language                 string                  `json:"language"`
-	ExternalEntityProviderID *string                 `json:"externalEntityProviderId" gorm:"type:text"`
+	SharesVulnInformation    bool           `json:"sharesVulnInformation"`
+	IsPublic                 bool           `json:"isPublic" gorm:"default:false;"`
+	ConfigFiles              map[string]any `json:"configFiles"`
+	Language                 string         `json:"language"`
+	ExternalEntityProviderID *string        `json:"externalEntityProviderId" gorm:"type:text"`
 }
 
 type OrgDetailsDTO struct {
 	OrgDTO
 	Members []UserDTO `json:"members"`
+}
+
+type OrgSettingsDTO struct {
+	OrgDetailsDTO
+	Webhooks []WebhookIntegrationDTO `json:"webhooks"`
 }

--- a/router/org_router.go
+++ b/router/org_router.go
@@ -68,6 +68,7 @@ func NewOrgRouter(
 	organizationRouter.GET("/dependency-proxy-urls/", dependencyProxyController.GetDependencyProxyURLs)
 	organizationRouter.PUT("/config-files/:config-file/", orgController.UpdateConfigFile, middlewares.NeededScope([]string{"manage"}), middlewares.OrganizationAccessControlMiddleware(shared.ObjectOrganization, shared.ActionUpdate))
 	organizationRouter.GET("/trigger-sync/", externalEntityProviderService.TriggerSync)
+	organizationRouter.GET("/settings/", orgController.AdminSettings, middlewares.NeededScope([]string{"manage"}), middlewares.OrganizationAccessControlMiddleware(shared.ObjectOrganization, shared.ActionUpdate))
 	organizationRouter.GET("/", orgController.Read)
 	organizationRouter.GET("/metrics/", orgController.Metrics)
 	organizationRouter.GET("/content-tree/", orgController.ContentTree)

--- a/transformer/org_transformer.go
+++ b/transformer/org_transformer.go
@@ -180,9 +180,18 @@ func OrgDTOFromModel(org models.Org) dtos.OrgDTO {
 		GithubAppInstallations:   utils.Map(org.GithubAppInstallations, GithubAppInstallationToDTO),
 		GitLabIntegrations:       utils.Map(org.GitLabIntegrations, obfuscateGitLabIntegrations),
 		JiraIntegrations:         utils.Map(org.JiraIntegrations, obfuscateJiraIntegrations),
-		Webhooks:                 utils.Map(org.Webhooks, obfuscateWebhookIntegrations),
 		ConfigFiles:              org.ConfigFiles,
 		Language:                 org.Language,
 		ExternalEntityProviderID: org.ExternalEntityProviderID,
+	}
+}
+
+func OrgSettingsDTOFromModel(org models.Org, members []dtos.UserDTO) dtos.OrgSettingsDTO {
+	return dtos.OrgSettingsDTO{
+		OrgDetailsDTO: dtos.OrgDetailsDTO{
+			OrgDTO:  OrgDTOFromModel(org),
+			Members: members,
+		},
+		Webhooks: utils.Map(org.Webhooks, obfuscateWebhookIntegrations),
 	}
 }


### PR DESCRIPTION
## Summary
- add a dedicated organization settings endpoint returning organization details
- protect the endpoint with manage scope and organization update RBAC for org admins/owners
- regenerate OpenAPI docs and add focused controller coverage

Fixes #1896

## Tests
- make docs
- go test ./controllers ./middlewares
- go test ./...
- git diff --check