### PR TITLE
Harden OCI proxy against SSRF (#1921)

### DIFF
--- a/controllers/dependencyfirewall/oci.go
+++ b/controllers/dependencyfirewall/oci.go
@@ -40,6 +40,18 @@ import (
 
 var ociProxyPrefixRe = regexp.MustCompile(`^/api/v1/dependency-proxy/(?:[^/]+/)?oci(?:/|$)`)
 
+// OCI Distribution Spec path-param formats. Anything outside these is
+// rejected at the edge so that path traversal, NUL injection, or other
+// surprises never reach the cache layer or the upstream registry.
+var (
+	// One image-name segment (e.g. "library", "nginx").
+	ociNameSegmentRe = regexp.MustCompile(`^[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*$`)
+	// Tag: 1-128 chars, alphanumeric/_/./-, must not start with . or -.
+	ociTagRe = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`)
+	// Digest: only sha256 supported by the proxy today.
+	ociDigestRe = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+)
+
 // OCIDependencyProxyController handles OCI registry proxy requests.
 // Image references must be fully qualified: <registry>/<image> (e.g. docker.io/library/nginx).
 // It embeds DependencyProxyController to reuse shared helpers and state.
@@ -145,6 +157,32 @@ func isAllowedRegistry(registry string) bool {
 		return false
 	}
 	return slices.Contains(allowedOCIRegistries, registry)
+}
+
+// validateOCIPathParams enforces the OCI Distribution Spec format on every
+// path-param Echo gives us. Anything malformed (path traversal, special
+// characters, wrong digest length) is refused before the proxy touches the
+// cache or the upstream registry.
+func validateOCIPathParams(c shared.Context) error {
+	for _, segment := range []string{c.Param("image"), c.Param("namespace"), c.Param("ns1"), c.Param("ns2")} {
+		if segment == "" {
+			continue
+		}
+		if !ociNameSegmentRe.MatchString(segment) {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid image name")
+		}
+	}
+	if ref := c.Param("reference"); ref != "" {
+		if !ociTagRe.MatchString(ref) && !ociDigestRe.MatchString(ref) {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid reference")
+		}
+	}
+	if dig := c.Param("digest"); dig != "" {
+		if !ociDigestRe.MatchString(dig) {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid digest")
+		}
+	}
+	return nil
 }
 
 // upstreamURLForRegistry returns the upstream base URL for a given registry
@@ -373,6 +411,9 @@ func (d *OCIDependencyProxyController) ProxyOCIManifest(c shared.Context) error 
 	if !isAllowedRegistry(registry) {
 		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
 	}
+	if err := validateOCIPathParams(c); err != nil {
+		return err
+	}
 	reference := c.Param("reference")
 	// Path sent to the upstream (no registry prefix).
 	upstreamPath := fmt.Sprintf("/v2/%s/manifests/%s", upstreamImagePath, reference)
@@ -483,6 +524,9 @@ func (d *OCIDependencyProxyController) ProxyOCIBlob(c shared.Context) error {
 	if !isAllowedRegistry(registry) {
 		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
 	}
+	if err := validateOCIPathParams(c); err != nil {
+		return err
+	}
 	digest := c.Param("digest")
 	upstreamPath := fmt.Sprintf("/v2/%s/blobs/%s", upstreamImagePath, digest)
 	requestPath := fmt.Sprintf("/v2/%s/blobs/%s", fqImageName, digest)
@@ -584,6 +628,9 @@ func (d *OCIDependencyProxyController) ProxyOCIReferrers(c shared.Context) error
 	if !isAllowedRegistry(registry) {
 		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
 	}
+	if err := validateOCIPathParams(c); err != nil {
+		return err
+	}
 	digest := c.Param("digest")
 	upstreamPath := fmt.Sprintf("/v2/%s/referrers/%s", upstreamImagePath, digest)
 
@@ -633,6 +680,9 @@ func (d *OCIDependencyProxyController) ProxyOCITagsList(c shared.Context) error 
 	registry, fqImageName, upstreamImagePath := imageParamsFromContext(c)
 	if !isAllowedRegistry(registry) {
 		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
+	}
+	if err := validateOCIPathParams(c); err != nil {
+		return err
 	}
 	upstreamPath := fmt.Sprintf("/v2/%s/tags/list", upstreamImagePath)
 

--- a/controllers/dependencyfirewall/oci.go
+++ b/controllers/dependencyfirewall/oci.go
@@ -22,10 +22,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -130,11 +132,27 @@ func ociSafeCachePath(requestPath string) string {
 	return strings.ReplaceAll(requestPath, ":", "_")
 }
 
-// upstreamURLForRegistry returns the upstream base URL for a given registry hostname.
-// docker.io is a special case: its actual API endpoint differs from the pull hostname.
+// isAllowedRegistry reports whether requests for the given :registry path
+// segment may proceed. IP literals and host:port forms are rejected outright
+// — they are never legitimate public-registry hostnames and have historically
+// been the SSRF entry point. Otherwise the registry must be one of the
+// supported registries listed in oci_registries.go.
+func isAllowedRegistry(registry string) bool {
+	if net.ParseIP(registry) != nil {
+		return false
+	}
+	if strings.Contains(registry, ":") {
+		return false
+	}
+	return slices.Contains(allowedOCIRegistries, registry)
+}
+
+// upstreamURLForRegistry returns the upstream base URL for a given registry
+// hostname, consulting the registry table in oci_registries.go (which is
+// where the docker.io → registry-1.docker.io rewrite lives).
 func upstreamURLForRegistry(registry string) string {
-	if registry == "docker.io" {
-		return "https://registry-1.docker.io"
+	if host, ok := registryUpstreamHosts[registry]; ok {
+		return "https://" + host
 	}
 	return "https://" + registry
 }
@@ -173,6 +191,28 @@ type dockerTokenResponse struct {
 	Token string `json:"token"`
 }
 
+// validateRealmHost rejects realm URLs that aren't HTTPS or that point to a
+// host the upstream registry isn't allowed to delegate to. Without this, a
+// malicious upstream could advertise realm="http://169.254.169.254/..." in
+// its 401 and DevGuard would issue a request to that internal address (SSRF,
+// issue #1921).
+func validateRealmHost(realm, upstreamHost string) error {
+	parsed, err := url.Parse(realm)
+	if err != nil {
+		return fmt.Errorf("realm is not a valid URL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("realm must use https, got %q", parsed.Scheme)
+	}
+	if parsed.Host == upstreamHost {
+		return nil
+	}
+	if slices.Contains(registryAuthHosts[upstreamHost], parsed.Host) {
+		return nil
+	}
+	return fmt.Errorf("realm host %q not allowed for registry %q", parsed.Host, upstreamHost)
+}
+
 // parseBearerChallenge extracts the realm, service and scope fields from a
 // WWW-Authenticate: Bearer header value so token fetching works for any
 // OCI-compliant registry without hardcoding auth URLs.
@@ -200,10 +240,14 @@ func parseBearerChallenge(header string) (realm, service, scope string) {
 // challenge advertised in the upstream 401 response.
 // The realm URL is validated against the upstream registry host to prevent SSRF:
 // a malicious registry could advertise realm="http://internal-host/" in its 401.
-func (d *OCIDependencyProxyController) fetchRegistryToken(ctx context.Context, wwwAuthenticate string) (string, error) {
+func (d *OCIDependencyProxyController) fetchRegistryToken(ctx context.Context, upstreamHost, wwwAuthenticate string) (string, error) {
 	realm, service, scope := parseBearerChallenge(wwwAuthenticate)
 	if realm == "" {
 		return "", fmt.Errorf("no realm in WWW-Authenticate header: %q", wwwAuthenticate)
+	}
+
+	if err := validateRealmHost(realm, upstreamHost); err != nil {
+		return "", err
 	}
 
 	params := url.Values{}
@@ -244,6 +288,12 @@ func (d *OCIDependencyProxyController) fetchRegistryToken(ctx context.Context, w
 func (d *OCIDependencyProxyController) fetchOCIFromUpstream(ctx context.Context, method, upstreamBase, requestPath string) ([]byte, http.Header, int, error) {
 	fullURL := upstreamBase + requestPath
 
+	parsedBase, err := url.Parse(upstreamBase)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("invalid upstream base URL: %w", err)
+	}
+	upstreamHost := parsedBase.Host
+
 	doRequest := func(token string) (*http.Response, error) {
 		req, err := http.NewRequestWithContext(ctx, method, fullURL, nil)
 		if err != nil {
@@ -271,7 +321,7 @@ func (d *OCIDependencyProxyController) fetchOCIFromUpstream(ctx context.Context,
 		wwwAuth := resp.Header.Get("Www-Authenticate")
 		resp.Body.Close()
 
-		token, err := d.fetchRegistryToken(ctx, wwwAuth)
+		token, err := d.fetchRegistryToken(ctx, upstreamHost, wwwAuth)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("failed to get registry token: %w", err)
 		}
@@ -320,6 +370,9 @@ func (d *OCIDependencyProxyController) ProxyOCIManifest(c shared.Context) error 
 	}
 
 	registry, fqImageName, upstreamImagePath := imageParamsFromContext(c)
+	if !isAllowedRegistry(registry) {
+		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
+	}
 	reference := c.Param("reference")
 	// Path sent to the upstream (no registry prefix).
 	upstreamPath := fmt.Sprintf("/v2/%s/manifests/%s", upstreamImagePath, reference)
@@ -427,6 +480,9 @@ func (d *OCIDependencyProxyController) ProxyOCIBlob(c shared.Context) error {
 	}
 
 	registry, fqImageName, upstreamImagePath := imageParamsFromContext(c)
+	if !isAllowedRegistry(registry) {
+		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
+	}
 	digest := c.Param("digest")
 	upstreamPath := fmt.Sprintf("/v2/%s/blobs/%s", upstreamImagePath, digest)
 	requestPath := fmt.Sprintf("/v2/%s/blobs/%s", fqImageName, digest)
@@ -525,6 +581,9 @@ func (d *OCIDependencyProxyController) ProxyOCIReferrers(c shared.Context) error
 	}
 
 	registry, fqImageName, upstreamImagePath := imageParamsFromContext(c)
+	if !isAllowedRegistry(registry) {
+		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
+	}
 	digest := c.Param("digest")
 	upstreamPath := fmt.Sprintf("/v2/%s/referrers/%s", upstreamImagePath, digest)
 
@@ -572,6 +631,9 @@ func (d *OCIDependencyProxyController) ProxyOCITagsList(c shared.Context) error 
 	}
 
 	registry, fqImageName, upstreamImagePath := imageParamsFromContext(c)
+	if !isAllowedRegistry(registry) {
+		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
+	}
 	upstreamPath := fmt.Sprintf("/v2/%s/tags/list", upstreamImagePath)
 
 	ctx, span := depProxyTracer.Start(c.Request().Context(), "dependency-proxy.oci",

--- a/controllers/dependencyfirewall/oci.go
+++ b/controllers/dependencyfirewall/oci.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -145,42 +144,30 @@ func ociSafeCachePath(requestPath string) string {
 }
 
 // isAllowedRegistry reports whether requests for the given :registry path
-// segment may proceed. IP literals and host:port forms are rejected outright
-// — they are never legitimate public-registry hostnames and have historically
-// been the SSRF entry point. Otherwise the registry must be one of the
-// supported registries listed in oci_registries.go.
+// segment may proceed. The registry must be one of the supported registries
+// listed in oci_registries.go — that list contains no IP literals or
+// host:port forms, so SSRF inputs (e.g. 169.254.169.254, docker.io:443) are
+// rejected as a side effect.
 func isAllowedRegistry(registry string) bool {
-	if net.ParseIP(registry) != nil {
-		return false
-	}
-	if strings.Contains(registry, ":") {
-		return false
-	}
 	return slices.Contains(allowedOCIRegistries, registry)
 }
 
 // validateOCIPathParams enforces the OCI Distribution Spec format on every
-// path-param Echo gives us. Anything malformed (path traversal, special
-// characters, wrong digest length) is refused before the proxy touches the
-// cache or the upstream registry.
-func validateOCIPathParams(c shared.Context) error {
-	for _, segment := range []string{c.Param("image"), c.Param("namespace"), c.Param("ns1"), c.Param("ns2")} {
-		if segment == "" {
-			continue
-		}
+// path-param the route handler extracted. Anything malformed (path traversal,
+// special characters, wrong digest length) is refused before the proxy
+// touches the cache or the upstream registry. reference and digest may be
+// empty for routes that don't carry them (e.g. /tags/list).
+func validateOCIPathParams(upstreamImagePath, reference, digest string) error {
+	for _, segment := range strings.Split(upstreamImagePath, "/") {
 		if !ociNameSegmentRe.MatchString(segment) {
 			return echo.NewHTTPError(http.StatusBadRequest, "invalid image name")
 		}
 	}
-	if ref := c.Param("reference"); ref != "" {
-		if !ociTagRe.MatchString(ref) && !ociDigestRe.MatchString(ref) {
-			return echo.NewHTTPError(http.StatusBadRequest, "invalid reference")
-		}
+	if reference != "" && !ociTagRe.MatchString(reference) && !ociDigestRe.MatchString(reference) {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid reference")
 	}
-	if dig := c.Param("digest"); dig != "" {
-		if !ociDigestRe.MatchString(dig) {
-			return echo.NewHTTPError(http.StatusBadRequest, "invalid digest")
-		}
+	if digest != "" && !ociDigestRe.MatchString(digest) {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid digest")
 	}
 	return nil
 }
@@ -411,10 +398,10 @@ func (d *OCIDependencyProxyController) ProxyOCIManifest(c shared.Context) error 
 	if !isAllowedRegistry(registry) {
 		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
 	}
-	if err := validateOCIPathParams(c); err != nil {
+	reference := c.Param("reference")
+	if err := validateOCIPathParams(upstreamImagePath, reference, ""); err != nil {
 		return err
 	}
-	reference := c.Param("reference")
 	// Path sent to the upstream (no registry prefix).
 	upstreamPath := fmt.Sprintf("/v2/%s/manifests/%s", upstreamImagePath, reference)
 	// Path used for caching and rule matching (includes registry).
@@ -524,10 +511,10 @@ func (d *OCIDependencyProxyController) ProxyOCIBlob(c shared.Context) error {
 	if !isAllowedRegistry(registry) {
 		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
 	}
-	if err := validateOCIPathParams(c); err != nil {
+	digest := c.Param("digest")
+	if err := validateOCIPathParams(upstreamImagePath, "", digest); err != nil {
 		return err
 	}
-	digest := c.Param("digest")
 	upstreamPath := fmt.Sprintf("/v2/%s/blobs/%s", upstreamImagePath, digest)
 	requestPath := fmt.Sprintf("/v2/%s/blobs/%s", fqImageName, digest)
 	method := c.Request().Method
@@ -628,10 +615,10 @@ func (d *OCIDependencyProxyController) ProxyOCIReferrers(c shared.Context) error
 	if !isAllowedRegistry(registry) {
 		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
 	}
-	if err := validateOCIPathParams(c); err != nil {
+	digest := c.Param("digest")
+	if err := validateOCIPathParams(upstreamImagePath, "", digest); err != nil {
 		return err
 	}
-	digest := c.Param("digest")
 	upstreamPath := fmt.Sprintf("/v2/%s/referrers/%s", upstreamImagePath, digest)
 
 	ctx, span := depProxyTracer.Start(c.Request().Context(), "dependency-proxy.oci",
@@ -681,7 +668,7 @@ func (d *OCIDependencyProxyController) ProxyOCITagsList(c shared.Context) error 
 	if !isAllowedRegistry(registry) {
 		return echo.NewHTTPError(http.StatusBadRequest, "registry not allowed")
 	}
-	if err := validateOCIPathParams(c); err != nil {
+	if err := validateOCIPathParams(upstreamImagePath, "", ""); err != nil {
 		return err
 	}
 	upstreamPath := fmt.Sprintf("/v2/%s/tags/list", upstreamImagePath)

--- a/controllers/dependencyfirewall/oci_integration_test.go
+++ b/controllers/dependencyfirewall/oci_integration_test.go
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 l3montree GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Integration tests that exercise the OCI proxy against a real (in-process)
+// HTTP/HTTPS server stood up via httptest. Pure unit tests live in oci_test.go.
+
+package dependencyfirewall
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ── fetchOCIFromUpstream — happy-path token auth ─────────────────────────────
+
+func TestFetchOCIFromUpstreamTokenAuth(t *testing.T) {
+	// TLS + same-host token endpoint: realm validation requires https and that
+	// the realm host either equals the upstream host or is allowlisted.
+	var server *httptest.Server
+	callCount := 0
+	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(dockerTokenResponse{Token: "test-token"})
+			return
+		}
+		callCount++
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("Www-Authenticate", `Bearer realm="`+server.URL+`/token",service="test-registry",scope="repository:library/nginx:pull"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+		_, _ = w.Write([]byte(`{"schemaVersion":2}`))
+	}))
+	defer server.Close()
+
+	ctrl := &OCIDependencyProxyController{
+		DependencyProxyController: &DependencyProxyController{client: server.Client()},
+	}
+
+	data, headers, status, err := ctrl.fetchOCIFromUpstream(
+		t.Context(),
+		http.MethodGet,
+		server.URL,
+		"/v2/library/nginx/manifests/latest",
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if !strings.Contains(string(data), "schemaVersion") {
+		t.Fatalf("unexpected body: %s", data)
+	}
+	if headers.Get("Content-Type") == "" {
+		t.Fatal("expected Content-Type header to be forwarded")
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 upstream calls (challenge + retry with token), got %d", callCount)
+	}
+}
+
+// ── fetchOCIFromUpstream — HEAD passthrough ──────────────────────────────────
+
+func TestFetchOCIFromUpstreamHEAD(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			http.Error(w, "want HEAD", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Docker-Content-Digest", "sha256:abc")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctrl := &OCIDependencyProxyController{
+		DependencyProxyController: &DependencyProxyController{client: srv.Client()},
+	}
+
+	data, headers, status, err := ctrl.fetchOCIFromUpstream(t.Context(), http.MethodHead, srv.URL, "/v2/library/nginx/manifests/latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if data != nil {
+		t.Fatal("expected nil body for HEAD response")
+	}
+	if headers.Get("Docker-Content-Digest") != "sha256:abc" {
+		t.Fatalf("expected digest header, got %q", headers.Get("Docker-Content-Digest"))
+	}
+}
+
+// ── End-to-end SSRF regression tests (issue #1921) ───────────────────────────
+
+// TestFetchOCIFromUpstreamRejectsSSRFRealmEndToEnd is the live PoC regression
+// for issue #1921. A real HTTPS upstream returns a 401 advertising a malicious
+// realm pointing at the AWS metadata IP. DevGuard must refuse before issuing
+// any token request — the server records every hit, and there must be exactly
+// one (the initial manifest fetch that produced the 401).
+func TestFetchOCIFromUpstreamRejectsSSRFRealmEndToEnd(t *testing.T) {
+	var hits []string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, r.URL.Path)
+		w.Header().Set("Www-Authenticate", `Bearer realm="http://169.254.169.254/latest/meta-data/",service="evil"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	ctrl := &OCIDependencyProxyController{
+		DependencyProxyController: &DependencyProxyController{client: server.Client()},
+	}
+
+	_, _, _, err := ctrl.fetchOCIFromUpstream(
+		t.Context(),
+		http.MethodGet,
+		server.URL,
+		"/v2/library/nginx/manifests/latest",
+	)
+	if err == nil {
+		t.Fatal("expected SSRF realm to be rejected, got no error")
+	}
+	if !strings.Contains(err.Error(), "realm must use https") {
+		t.Fatalf("expected 'realm must use https' error, got %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly one upstream hit (the 401 challenge), got %d: %v", len(hits), hits)
+	}
+	if hits[0] != "/v2/library/nginx/manifests/latest" {
+		t.Fatalf("unexpected upstream path: %q", hits[0])
+	}
+}
+
+// TestFetchOCIFromUpstreamRejectsForeignRealmEndToEnd verifies that even when
+// the malicious upstream serves over HTTPS, a realm pointing at a host outside
+// the registry's allowlist is refused (and no token request is issued).
+func TestFetchOCIFromUpstreamRejectsForeignRealmEndToEnd(t *testing.T) {
+	var hits []string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, r.URL.Path)
+		w.Header().Set("Www-Authenticate", `Bearer realm="https://attacker.example/token",service="evil"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	ctrl := &OCIDependencyProxyController{
+		DependencyProxyController: &DependencyProxyController{client: server.Client()},
+	}
+
+	_, _, _, err := ctrl.fetchOCIFromUpstream(
+		t.Context(),
+		http.MethodGet,
+		server.URL,
+		"/v2/library/nginx/manifests/latest",
+	)
+	if err == nil {
+		t.Fatal("expected foreign realm to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected 'not allowed' error, got %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly one upstream hit, got %d: %v", len(hits), hits)
+	}
+}

--- a/controllers/dependencyfirewall/oci_registries.go
+++ b/controllers/dependencyfirewall/oci_registries.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 l3montree GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// This file is the single source of truth for which OCI registries DevGuard
+// proxies and how it authenticates with each one. Add or remove an entry in
+// supportedOCIRegistries below — every lookup table is derived from it in
+// init(), so the allowlist, auth-host map, and upstream URL map stay in sync.
+
+package dependencyfirewall
+
+// supportedOCIRegistry describes one upstream registry DevGuard knows how to proxy.
+type supportedOCIRegistry struct {
+	// pathName is the path segment users send: /v2/<pathName>/...
+	pathName string
+	// upstreamHost is the host DevGuard actually connects to. For most
+	// registries this equals pathName; docker.io is the exception — its pull
+	// endpoint is registry-1.docker.io.
+	upstreamHost string
+	// authHosts are additional hosts allowed to issue tokens via the
+	// WWW-Authenticate realm. Same-host delegation is always permitted; this
+	// list only covers cross-host cases (e.g. docker.io → auth.docker.io).
+	authHosts []string
+}
+
+var supportedOCIRegistries = []supportedOCIRegistry{
+	{pathName: "docker.io", upstreamHost: "registry-1.docker.io", authHosts: []string{"auth.docker.io"}},
+	{pathName: "ghcr.io", upstreamHost: "ghcr.io"},
+	{pathName: "quay.io", upstreamHost: "quay.io"},
+	{pathName: "gcr.io", upstreamHost: "gcr.io"},
+	{pathName: "registry.k8s.io", upstreamHost: "registry.k8s.io"},
+	{pathName: "public.ecr.aws", upstreamHost: "public.ecr.aws"},
+	{pathName: "mcr.microsoft.com", upstreamHost: "mcr.microsoft.com"},
+}
+
+// Lookup tables derived from supportedOCIRegistries in init().
+var (
+	allowedOCIRegistries  []string            // pathNames accepted at the proxy edge
+	registryAuthHosts     map[string][]string // upstreamHost → permitted token-issuer hosts
+	registryUpstreamHosts map[string]string   // pathName → upstreamHost
+)
+
+func init() {
+	allowedOCIRegistries = make([]string, 0, len(supportedOCIRegistries))
+	registryAuthHosts = make(map[string][]string, len(supportedOCIRegistries))
+	registryUpstreamHosts = make(map[string]string, len(supportedOCIRegistries))
+	for _, r := range supportedOCIRegistries {
+		allowedOCIRegistries = append(allowedOCIRegistries, r.pathName)
+		registryAuthHosts[r.upstreamHost] = r.authHosts
+		registryUpstreamHosts[r.pathName] = r.upstreamHost
+	}
+}

--- a/controllers/dependencyfirewall/oci_registries.go
+++ b/controllers/dependencyfirewall/oci_registries.go
@@ -42,6 +42,7 @@ var supportedOCIRegistries = []supportedOCIRegistry{
 	{pathName: "registry.k8s.io", upstreamHost: "registry.k8s.io"},
 	{pathName: "public.ecr.aws", upstreamHost: "public.ecr.aws"},
 	{pathName: "mcr.microsoft.com", upstreamHost: "mcr.microsoft.com"},
+	{pathName: "registry.gitlab.com", upstreamHost: "registry.gitlab.com", authHosts: []string{"gitlab.com"}},
 }
 
 // Lookup tables derived from supportedOCIRegistries in init().

--- a/controllers/dependencyfirewall/oci_test.go
+++ b/controllers/dependencyfirewall/oci_test.go
@@ -224,14 +224,14 @@ func TestOCINameSegmentRegex(t *testing.T) {
 	valid := []string{"nginx", "library", "node-exporter", "my_image", "my.image", "my__image", "a", "abc123"}
 	invalid := []string{
 		"",
-		"NGINX",                   // uppercase
-		"-nginx",                  // leading dash
-		".nginx",                  // leading dot
-		"nginx/",                  // slash
-		"my image",                // space
-		"../etc",                  // traversal
-		"image:tag",               // colon
-		"image@sha256",            // at-sign
+		"NGINX",        // uppercase
+		"-nginx",       // leading dash
+		".nginx",       // leading dot
+		"nginx/",       // slash
+		"my image",     // space
+		"../etc",       // traversal
+		"image:tag",    // colon
+		"image@sha256", // at-sign
 	}
 	for _, s := range valid {
 		if !ociNameSegmentRe.MatchString(s) {
@@ -249,11 +249,11 @@ func TestOCITagRegex(t *testing.T) {
 	valid := []string{"latest", "v1.7.0", "1.0_alpha", "stable-2024", "_underscore", "a"}
 	invalid := []string{
 		"",
-		".latest",                          // leading dot
-		"-latest",                          // leading dash
+		".latest", // leading dot
+		"-latest", // leading dash
 		"tag with space",
 		"tag/with/slash",
-		strings.Repeat("a", 129),           // > 128 chars
+		strings.Repeat("a", 129), // > 128 chars
 	}
 	for _, s := range valid {
 		if !ociTagRe.MatchString(s) {
@@ -275,12 +275,12 @@ func TestOCIDigestRegex(t *testing.T) {
 	}
 	invalid := []string{
 		"",
-		"sha256:",                                   // empty hex
-		"sha256:abc",                                // too short
-		"sha256:" + strings.Repeat("a", 63),         // 63 chars
-		"sha256:" + strings.Repeat("a", 65),         // 65 chars
-		"sha256:" + strings.Repeat("A", 64),         // uppercase
-		"sha512:" + strings.Repeat("a", 64),         // wrong algorithm
+		"sha256:",                           // empty hex
+		"sha256:abc",                        // too short
+		"sha256:" + strings.Repeat("a", 63), // 63 chars
+		"sha256:" + strings.Repeat("a", 65), // 65 chars
+		"sha256:" + strings.Repeat("A", 64), // uppercase
+		"sha512:" + strings.Repeat("a", 64), // wrong algorithm
 		"abc",
 	}
 	for _, s := range valid {
@@ -300,57 +300,66 @@ func TestOCIDigestRegex(t *testing.T) {
 func TestValidateOCIPathParams(t *testing.T) {
 	validDigest := "sha256:" + strings.Repeat("a", 64)
 	cases := []struct {
-		name    string
-		params  map[string]string
-		wantErr string
+		name              string
+		upstreamImagePath string
+		reference         string
+		digest            string
+		wantErr           string
 	}{
 		{
-			name:   "valid 2-segment manifest by tag",
-			params: map[string]string{"namespace": "library", "image": "nginx", "reference": "latest"},
+			name:              "valid 2-segment manifest by tag",
+			upstreamImagePath: "library/nginx",
+			reference:         "latest",
 		},
 		{
-			name:   "valid manifest by digest reference",
-			params: map[string]string{"namespace": "library", "image": "nginx", "reference": validDigest},
+			name:              "valid manifest by digest reference",
+			upstreamImagePath: "library/nginx",
+			reference:         validDigest,
 		},
 		{
-			name:   "valid blob digest",
-			params: map[string]string{"namespace": "library", "image": "nginx", "digest": validDigest},
+			name:              "valid blob digest",
+			upstreamImagePath: "library/nginx",
+			digest:            validDigest,
 		},
 		{
-			name:    "path traversal in image",
-			params:  map[string]string{"image": "../../../etc/passwd"},
-			wantErr: "invalid image name",
+			name:              "path traversal in image",
+			upstreamImagePath: "../../../etc/passwd",
+			wantErr:           "invalid image name",
 		},
 		{
-			name:    "uppercase in namespace",
-			params:  map[string]string{"namespace": "Library", "image": "nginx", "reference": "latest"},
-			wantErr: "invalid image name",
+			name:              "uppercase in namespace",
+			upstreamImagePath: "Library/nginx",
+			reference:         "latest",
+			wantErr:           "invalid image name",
 		},
 		{
-			name:    "tag starting with dot",
-			params:  map[string]string{"image": "nginx", "reference": ".hidden"},
-			wantErr: "invalid reference",
+			name:              "tag starting with dot",
+			upstreamImagePath: "nginx",
+			reference:         ".hidden",
+			wantErr:           "invalid reference",
 		},
 		{
-			name:    "digest too short",
-			params:  map[string]string{"image": "nginx", "digest": "sha256:abc"},
-			wantErr: "invalid digest",
+			name:              "digest too short",
+			upstreamImagePath: "nginx",
+			digest:            "sha256:abc",
+			wantErr:           "invalid digest",
 		},
 		{
-			name:    "digest wrong algorithm",
-			params:  map[string]string{"image": "nginx", "digest": "sha512:" + strings.Repeat("a", 64)},
-			wantErr: "invalid digest",
+			name:              "digest wrong algorithm",
+			upstreamImagePath: "nginx",
+			digest:            "sha512:" + strings.Repeat("a", 64),
+			wantErr:           "invalid digest",
 		},
 		{
-			name:    "3-segment ghcr.io with bad ns2",
-			params:  map[string]string{"ns1": "org", "ns2": "../escape", "image": "repo", "reference": "latest"},
-			wantErr: "invalid image name",
+			name:              "3-segment ghcr.io with bad ns2",
+			upstreamImagePath: "org/../escape/repo",
+			reference:         "latest",
+			wantErr:           "invalid image name",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := newTestEchoContext(tc.params)
-			err := validateOCIPathParams(c)
+			err := validateOCIPathParams(tc.upstreamImagePath, tc.reference, tc.digest)
 			if tc.wantErr == "" {
 				if err != nil {
 					t.Fatalf("expected no error, got %v", err)

--- a/controllers/dependencyfirewall/oci_test.go
+++ b/controllers/dependencyfirewall/oci_test.go
@@ -175,6 +175,49 @@ func TestOCISafeCachePath(t *testing.T) {
 	}
 }
 
+// ── isAllowedRegistry ────────────────────────────────────────────────────────
+
+func TestIsAllowedRegistry(t *testing.T) {
+	cases := map[string]bool{
+		"docker.io":         true,
+		"ghcr.io":           true,
+		"quay.io":           true,
+		"gcr.io":            true,
+		"registry.k8s.io":   true,
+		"public.ecr.aws":    true,
+		"mcr.microsoft.com": true,
+		"evil.com":          false,
+		"unknown.io":        false,
+		"1.2.3.4":           false, // IPv4 literal
+		"::1":               false, // IPv6 literal
+		"docker.io:443":     false, // host:port form
+		"":                  false,
+	}
+	for input, want := range cases {
+		if got := isAllowedRegistry(input); got != want {
+			t.Errorf("isAllowedRegistry(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+// TestSupportedOCIRegistriesDerivations ensures the lookup tables stay in
+// sync with the supportedOCIRegistries source list. If someone adds an entry
+// to the list but a derived map isn't rebuilt (e.g. init() bug), this fails.
+func TestSupportedOCIRegistriesDerivations(t *testing.T) {
+	if len(allowedOCIRegistries) != len(supportedOCIRegistries) {
+		t.Fatalf("allowedOCIRegistries size mismatch: got %d, want %d",
+			len(allowedOCIRegistries), len(supportedOCIRegistries))
+	}
+	for _, r := range supportedOCIRegistries {
+		if _, ok := registryUpstreamHosts[r.pathName]; !ok {
+			t.Errorf("registryUpstreamHosts missing entry for %q", r.pathName)
+		}
+		if _, ok := registryAuthHosts[r.upstreamHost]; !ok {
+			t.Errorf("registryAuthHosts missing entry for %q", r.upstreamHost)
+		}
+	}
+}
+
 // ── upstreamURLForRegistry ────────────────────────────────────────────────────
 
 func TestUpstreamURLForRegistry(t *testing.T) {
@@ -418,82 +461,134 @@ func TestProxyOCIVersionCheck(t *testing.T) {
 	}
 }
 
-// ── fetchOCIFromUpstream ─────────────────────────────────────────────────────
+// ── validateRealmHost ────────────────────────────────────────────────────────
 
-func TestFetchOCIFromUpstreamTokenAuth(t *testing.T) {
-	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(dockerTokenResponse{Token: "test-token"})
-	}))
-	defer tokenServer.Close()
-
-	callCount := 0
-	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		if r.Header.Get("Authorization") == "" {
-			w.Header().Set("Www-Authenticate", `Bearer realm="`+tokenServer.URL+`",service="test-registry",scope="repository:library/nginx:pull"`)
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
-		_, _ = w.Write([]byte(`{"schemaVersion":2}`))
-	}))
-	defer registryServer.Close()
-
-	ctrl := &OCIDependencyProxyController{
-		DependencyProxyController: &DependencyProxyController{client: registryServer.Client()},
+func TestValidateRealmHost(t *testing.T) {
+	cases := []struct {
+		name         string
+		realm        string
+		upstreamHost string
+		wantErr      string
+	}{
+		{
+			name:         "same-host https realm passes",
+			realm:        "https://example.com/token",
+			upstreamHost: "example.com",
+		},
+		{
+			name:         "allowlisted delegation passes",
+			realm:        "https://auth.docker.io/token",
+			upstreamHost: "registry-1.docker.io",
+		},
+		{
+			name:         "non-https realm rejected",
+			realm:        "http://example.com/token",
+			upstreamHost: "example.com",
+			wantErr:      "realm must use https",
+		},
+		{
+			name:         "SSRF realm to metadata IP rejected",
+			realm:        "http://169.254.169.254/latest/meta-data/",
+			upstreamHost: "evil.com",
+			wantErr:      "realm must use https",
+		},
+		{
+			name:         "https foreign host rejected for known registry",
+			realm:        "https://attacker.example/token",
+			upstreamHost: "registry-1.docker.io",
+			wantErr:      "not allowed",
+		},
+		{
+			name:         "unknown registry has no allowed delegation hosts",
+			realm:        "https://attacker.example/token",
+			upstreamHost: "evil.com",
+			wantErr:      "not allowed",
+		},
+		{
+			name:         "malformed realm rejected",
+			realm:        "://invalid",
+			upstreamHost: "example.com",
+			wantErr:      "realm is not a valid URL",
+		},
 	}
-
-	data, headers, status, err := ctrl.fetchOCIFromUpstream(
-		t.Context(),
-		http.MethodGet,
-		registryServer.URL,
-		"/v2/library/nginx/manifests/latest",
-	)
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if status != http.StatusOK {
-		t.Fatalf("expected 200, got %d", status)
-	}
-	if !strings.Contains(string(data), "schemaVersion") {
-		t.Fatalf("unexpected body: %s", data)
-	}
-	if headers.Get("Content-Type") == "" {
-		t.Fatal("expected Content-Type header to be forwarded")
-	}
-	if callCount != 2 {
-		t.Fatalf("expected 2 upstream calls (challenge + retry with token), got %d", callCount)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRealmHost(tc.realm, tc.upstreamHost)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
 	}
 }
 
-func TestFetchOCIFromUpstreamHEAD(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodHead {
-			http.Error(w, "want HEAD", http.StatusMethodNotAllowed)
-			return
-		}
-		w.Header().Set("Docker-Content-Digest", "sha256:abc")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+// ── fetchRegistryToken realm validation ──────────────────────────────────────
 
+// TestFetchRegistryTokenRejectsSSRFRealm reproduces the PoC from issue #1921:
+// a malicious registry advertises realm pointing at an internal address.
+// The fix must reject this before any HTTP request is issued.
+func TestFetchRegistryTokenRejectsSSRFRealm(t *testing.T) {
 	ctrl := &OCIDependencyProxyController{
-		DependencyProxyController: &DependencyProxyController{client: srv.Client()},
+		DependencyProxyController: &DependencyProxyController{client: http.DefaultClient},
 	}
 
-	data, headers, status, err := ctrl.fetchOCIFromUpstream(t.Context(), http.MethodHead, srv.URL, "/v2/library/nginx/manifests/latest")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	poc := `Bearer realm="http://169.254.169.254/latest/meta-data/",service="evil"`
+	token, err := ctrl.fetchRegistryToken(t.Context(), "evil.com", poc)
+	if err == nil {
+		t.Fatalf("expected SSRF realm to be rejected, got token=%q", token)
 	}
-	if status != http.StatusOK {
-		t.Fatalf("expected 200, got %d", status)
+	if token != "" {
+		t.Fatalf("expected empty token on rejection, got %q", token)
 	}
-	if data != nil {
-		t.Fatal("expected nil body for HEAD response")
+}
+
+func TestFetchRegistryTokenRejectsForeignHost(t *testing.T) {
+	ctrl := &OCIDependencyProxyController{
+		DependencyProxyController: &DependencyProxyController{client: http.DefaultClient},
 	}
-	if headers.Get("Docker-Content-Digest") != "sha256:abc" {
-		t.Fatalf("expected digest header, got %q", headers.Get("Docker-Content-Digest"))
+
+	// docker.io legitimately delegates to auth.docker.io; a foreign host must be refused.
+	header := `Bearer realm="https://attacker.example/token",service="registry.docker.io"`
+	_, err := ctrl.fetchRegistryToken(t.Context(), "registry-1.docker.io", header)
+	if err == nil {
+		t.Fatal("expected foreign host realm to be rejected")
 	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected 'not allowed' error, got %v", err)
+	}
+}
+
+func TestFetchRegistryTokenAcceptsAllowlistedDelegation(t *testing.T) {
+	// When the realm points to an allowlisted delegation host, validation passes
+	// and we attempt the token call (which then fails because we're not actually
+	// talking to auth.docker.io). The test asserts the validator did not block;
+	// any error must be from the network/transport layer, not realm validation.
+	ctrl := &OCIDependencyProxyController{
+		DependencyProxyController: &DependencyProxyController{client: &http.Client{Transport: errTransport{}}},
+	}
+
+	header := `Bearer realm="https://auth.docker.io/token",service="registry.docker.io"`
+	_, err := ctrl.fetchRegistryToken(t.Context(), "registry-1.docker.io", header)
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	if strings.Contains(err.Error(), "not allowed") || strings.Contains(err.Error(), "must use https") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+// errTransport short-circuits any HTTP call so tests that want to verify the
+// validator without hitting the network can do so deterministically.
+type errTransport struct{}
+
+func (errTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, http.ErrHandlerTimeout
 }

--- a/controllers/dependencyfirewall/oci_test.go
+++ b/controllers/dependencyfirewall/oci_test.go
@@ -218,6 +218,155 @@ func TestSupportedOCIRegistriesDerivations(t *testing.T) {
 	}
 }
 
+// ── OCI path-param regexes ───────────────────────────────────────────────────
+
+func TestOCINameSegmentRegex(t *testing.T) {
+	valid := []string{"nginx", "library", "node-exporter", "my_image", "my.image", "my__image", "a", "abc123"}
+	invalid := []string{
+		"",
+		"NGINX",                   // uppercase
+		"-nginx",                  // leading dash
+		".nginx",                  // leading dot
+		"nginx/",                  // slash
+		"my image",                // space
+		"../etc",                  // traversal
+		"image:tag",               // colon
+		"image@sha256",            // at-sign
+	}
+	for _, s := range valid {
+		if !ociNameSegmentRe.MatchString(s) {
+			t.Errorf("expected %q to match name-segment regex", s)
+		}
+	}
+	for _, s := range invalid {
+		if ociNameSegmentRe.MatchString(s) {
+			t.Errorf("expected %q to NOT match name-segment regex", s)
+		}
+	}
+}
+
+func TestOCITagRegex(t *testing.T) {
+	valid := []string{"latest", "v1.7.0", "1.0_alpha", "stable-2024", "_underscore", "a"}
+	invalid := []string{
+		"",
+		".latest",                          // leading dot
+		"-latest",                          // leading dash
+		"tag with space",
+		"tag/with/slash",
+		strings.Repeat("a", 129),           // > 128 chars
+	}
+	for _, s := range valid {
+		if !ociTagRe.MatchString(s) {
+			t.Errorf("expected %q to match tag regex", s)
+		}
+	}
+	for _, s := range invalid {
+		if ociTagRe.MatchString(s) {
+			t.Errorf("expected %q to NOT match tag regex", s)
+		}
+	}
+}
+
+func TestOCIDigestRegex(t *testing.T) {
+	valid := []string{
+		"sha256:" + strings.Repeat("a", 64),
+		"sha256:" + strings.Repeat("0", 64),
+		"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	}
+	invalid := []string{
+		"",
+		"sha256:",                                   // empty hex
+		"sha256:abc",                                // too short
+		"sha256:" + strings.Repeat("a", 63),         // 63 chars
+		"sha256:" + strings.Repeat("a", 65),         // 65 chars
+		"sha256:" + strings.Repeat("A", 64),         // uppercase
+		"sha512:" + strings.Repeat("a", 64),         // wrong algorithm
+		"abc",
+	}
+	for _, s := range valid {
+		if !ociDigestRe.MatchString(s) {
+			t.Errorf("expected %q to match digest regex", s)
+		}
+	}
+	for _, s := range invalid {
+		if ociDigestRe.MatchString(s) {
+			t.Errorf("expected %q to NOT match digest regex", s)
+		}
+	}
+}
+
+// ── validateOCIPathParams ────────────────────────────────────────────────────
+
+func TestValidateOCIPathParams(t *testing.T) {
+	validDigest := "sha256:" + strings.Repeat("a", 64)
+	cases := []struct {
+		name    string
+		params  map[string]string
+		wantErr string
+	}{
+		{
+			name:   "valid 2-segment manifest by tag",
+			params: map[string]string{"namespace": "library", "image": "nginx", "reference": "latest"},
+		},
+		{
+			name:   "valid manifest by digest reference",
+			params: map[string]string{"namespace": "library", "image": "nginx", "reference": validDigest},
+		},
+		{
+			name:   "valid blob digest",
+			params: map[string]string{"namespace": "library", "image": "nginx", "digest": validDigest},
+		},
+		{
+			name:    "path traversal in image",
+			params:  map[string]string{"image": "../../../etc/passwd"},
+			wantErr: "invalid image name",
+		},
+		{
+			name:    "uppercase in namespace",
+			params:  map[string]string{"namespace": "Library", "image": "nginx", "reference": "latest"},
+			wantErr: "invalid image name",
+		},
+		{
+			name:    "tag starting with dot",
+			params:  map[string]string{"image": "nginx", "reference": ".hidden"},
+			wantErr: "invalid reference",
+		},
+		{
+			name:    "digest too short",
+			params:  map[string]string{"image": "nginx", "digest": "sha256:abc"},
+			wantErr: "invalid digest",
+		},
+		{
+			name:    "digest wrong algorithm",
+			params:  map[string]string{"image": "nginx", "digest": "sha512:" + strings.Repeat("a", 64)},
+			wantErr: "invalid digest",
+		},
+		{
+			name:    "3-segment ghcr.io with bad ns2",
+			params:  map[string]string{"ns1": "org", "ns2": "../escape", "image": "repo", "reference": "latest"},
+			wantErr: "invalid image name",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestEchoContext(tc.params)
+			err := validateOCIPathParams(c)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 // ── upstreamURLForRegistry ────────────────────────────────────────────────────
 
 func TestUpstreamURLForRegistry(t *testing.T) {

--- a/controllers/dependencyfirewall/oci_test.go
+++ b/controllers/dependencyfirewall/oci_test.go
@@ -186,6 +186,7 @@ func TestIsAllowedRegistry(t *testing.T) {
 		"registry.k8s.io":   true,
 		"public.ecr.aws":    true,
 		"mcr.microsoft.com": true,
+		"registry.gitlab.com": true,
 		"evil.com":          false,
 		"unknown.io":        false,
 		"1.2.3.4":           false, // IPv4 literal

--- a/middlewares/server.go
+++ b/middlewares/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/shared"
@@ -40,7 +41,15 @@ func registerMiddlewares(e *echo.Echo) {
 	// Expose the trace ID to the client so it can be referenced in Jaeger / GlitchTip.
 	e.Use(traceID())
 
-	e.Pre(middleware.AddTrailingSlash())
+	// AddTrailingSlash normalises REST endpoints, but it must be skipped for
+	// the OCI Distribution Spec routes — /v2/<name>/manifests/<reference> and
+	// friends are defined without trailing slashes, and adding one causes
+	// every registry (ghcr.io, quay.io, ...) to return 404.
+	e.Pre(middleware.AddTrailingSlashWithConfig(middleware.TrailingSlashConfig{
+		Skipper: func(c echo.Context) bool {
+			return strings.HasPrefix(c.Request().URL.Path, "/v2/")
+		},
+	}))
 	e.Use(middleware.CORSWithConfig(
 		middleware.CORSConfig{
 			AllowOrigins:     []string{"http://localhost:3000"},

--- a/router/oci_registry_router.go
+++ b/router/oci_registry_router.go
@@ -16,10 +16,20 @@
 package router
 
 import (
+	"os"
+
 	"github.com/l3montree-dev/devguard/cmd/devguard/api"
 	"github.com/l3montree-dev/devguard/controllers/dependencyfirewall"
 	"github.com/labstack/echo/v4"
 )
+
+// ociPublicProxyEnabled reports whether the unauthenticated /v2/<registry>/...
+// routes should be registered. Defaults to enabled; set
+// DEPENDENCY_PROXY_OCI_PUBLIC_ENABLED=false to lock the proxy down to
+// secret-scoped routes only.
+func ociPublicProxyEnabled() bool {
+	return os.Getenv("DEPENDENCY_PROXY_OCI_PUBLIC_ENABLED") != "false"
+}
 
 // OCIRegistryRouter exposes the OCI Distribution Spec v2 API at the root /v2/ path
 // so that standard Docker clients can pull images without any special configuration.
@@ -56,22 +66,25 @@ func NewOCIRegistryRouter(srv api.Server, ociController *dependencyfirewall.OCID
 	// ── Unauthenticated routes ──────────────────────────────────────────────
 	// No secret in path; GetDependencyProxyConfigs returns empty config (no rules).
 	// Malicious-package and path-traversal checks still run.
+	// Operators can disable these routes entirely via
+	// DEPENDENCY_PROXY_OCI_PUBLIC_ENABLED=false.
+	if ociPublicProxyEnabled() {
+		// 1-segment image: docker.io/nginx
+		v2.GET("/:registry/:image/manifests/:reference", ociController.ProxyOCIManifest)
+		v2.HEAD("/:registry/:image/manifests/:reference", ociController.ProxyOCIManifest)
+		v2.GET("/:registry/:image/blobs/:digest", ociController.ProxyOCIBlob)
+		v2.HEAD("/:registry/:image/blobs/:digest", ociController.ProxyOCIBlob)
+		v2.GET("/:registry/:image/tags/list", ociController.ProxyOCITagsList)
+		v2.GET("/:registry/:image/referrers/:digest", ociController.ProxyOCIReferrers)
 
-	// 1-segment image: docker.io/nginx
-	v2.GET("/:registry/:image/manifests/:reference", ociController.ProxyOCIManifest)
-	v2.HEAD("/:registry/:image/manifests/:reference", ociController.ProxyOCIManifest)
-	v2.GET("/:registry/:image/blobs/:digest", ociController.ProxyOCIBlob)
-	v2.HEAD("/:registry/:image/blobs/:digest", ociController.ProxyOCIBlob)
-	v2.GET("/:registry/:image/tags/list", ociController.ProxyOCITagsList)
-	v2.GET("/:registry/:image/referrers/:digest", ociController.ProxyOCIReferrers)
-
-	// 2-segment image: docker.io/library/nginx
-	v2.GET("/:registry/:namespace/:image/manifests/:reference", ociController.ProxyOCIManifest)
-	v2.HEAD("/:registry/:namespace/:image/manifests/:reference", ociController.ProxyOCIManifest)
-	v2.GET("/:registry/:namespace/:image/blobs/:digest", ociController.ProxyOCIBlob)
-	v2.HEAD("/:registry/:namespace/:image/blobs/:digest", ociController.ProxyOCIBlob)
-	v2.GET("/:registry/:namespace/:image/tags/list", ociController.ProxyOCITagsList)
-	v2.GET("/:registry/:namespace/:image/referrers/:digest", ociController.ProxyOCIReferrers)
+		// 2-segment image: docker.io/library/nginx
+		v2.GET("/:registry/:namespace/:image/manifests/:reference", ociController.ProxyOCIManifest)
+		v2.HEAD("/:registry/:namespace/:image/manifests/:reference", ociController.ProxyOCIManifest)
+		v2.GET("/:registry/:namespace/:image/blobs/:digest", ociController.ProxyOCIBlob)
+		v2.HEAD("/:registry/:namespace/:image/blobs/:digest", ociController.ProxyOCIBlob)
+		v2.GET("/:registry/:namespace/:image/tags/list", ociController.ProxyOCITagsList)
+		v2.GET("/:registry/:namespace/:image/referrers/:digest", ociController.ProxyOCIReferrers)
+	}
 
 	// ── Secret-scoped routes ────────────────────────────────────────────────
 	// Secret is the first path segment; custom firewall rules are loaded for

--- a/router/oci_registry_router_test.go
+++ b/router/oci_registry_router_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 l3montree GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package router
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/l3montree-dev/devguard/cmd/devguard/api"
+	"github.com/l3montree-dev/devguard/controllers/dependencyfirewall"
+)
+
+const (
+	pathUnauthManifest1Seg = "/v2/:registry/:image/manifests/:reference"
+	pathUnauthManifest2Seg = "/v2/:registry/:namespace/:image/manifests/:reference"
+	pathSecretManifest2Seg = "/v2/:secret/:registry/:namespace/:image/manifests/:reference"
+	pathVersionCheck       = "/v2/"
+)
+
+func TestOCIRegistryRouterPublicKillSwitch(t *testing.T) {
+	// A nil-embedded controller is fine — Echo stores method values on route
+	// registration, the handlers themselves are never invoked here.
+	ctrl := &dependencyfirewall.OCIDependencyProxyController{}
+
+	t.Run("default registers both unauth and secret-scoped routes", func(t *testing.T) {
+		t.Setenv("DEPENDENCY_PROXY_OCI_PUBLIC_ENABLED", "")
+		paths := registerRoutesAndList(ctrl)
+
+		if !slices.Contains(paths, pathUnauthManifest1Seg) {
+			t.Error("expected 1-segment unauth manifest route to be registered")
+		}
+		if !slices.Contains(paths, pathUnauthManifest2Seg) {
+			t.Error("expected 2-segment unauth manifest route to be registered")
+		}
+		if !slices.Contains(paths, pathSecretManifest2Seg) {
+			t.Error("expected secret-scoped route to be registered")
+		}
+		if !slices.Contains(paths, pathVersionCheck) {
+			t.Error("expected version check route to be registered")
+		}
+	})
+
+	t.Run("explicit true behaves like default", func(t *testing.T) {
+		t.Setenv("DEPENDENCY_PROXY_OCI_PUBLIC_ENABLED", "true")
+		paths := registerRoutesAndList(ctrl)
+
+		if !slices.Contains(paths, pathUnauthManifest1Seg) {
+			t.Error("expected unauth route to be registered when explicit true")
+		}
+	})
+
+	t.Run("kill switch removes unauth routes but keeps secret-scoped", func(t *testing.T) {
+		t.Setenv("DEPENDENCY_PROXY_OCI_PUBLIC_ENABLED", "false")
+		paths := registerRoutesAndList(ctrl)
+
+		if slices.Contains(paths, pathUnauthManifest1Seg) {
+			t.Error("expected 1-segment unauth route to NOT be registered when killswitch active")
+		}
+		if slices.Contains(paths, pathUnauthManifest2Seg) {
+			t.Error("expected 2-segment unauth route to NOT be registered when killswitch active")
+		}
+		if !slices.Contains(paths, pathSecretManifest2Seg) {
+			t.Error("expected secret-scoped route to remain registered")
+		}
+		if !slices.Contains(paths, pathVersionCheck) {
+			t.Error("expected version check route to remain registered")
+		}
+	})
+}
+
+func registerRoutesAndList(ctrl *dependencyfirewall.OCIDependencyProxyController) []string {
+	srv := api.Server{Echo: echo.New()}
+	NewOCIRegistryRouter(srv, ctrl)
+
+	routes := srv.Echo.Routes()
+	paths := make([]string, 0, len(routes))
+	for _, r := range routes {
+		paths = append(paths, r.Path)
+	}
+	return paths
+}


### PR DESCRIPTION
https://github.com/l3montree-dev/devguard/issues/1921

Changes made in the PR:



  1. Check the realm before fetching a token

  A bad registry could return a fake realm URL pointing to a private IP (like AWS metadata). The proxy used to follow it blindly. Now we check the realm first:

  - it must be a valid URL
  - it must use HTTPS
  - it must point to the same host as the registry, or a host we trust for that registry

  If any check fails, the token call is never made.

  2. Allowlist of registries:

The :registry part of the URL used to accept anything. Now only seven public registries are allowed: docker.io, ghcr.io, quay.io, gcr.io, registry.k8s.io, public.ecr.aws, mcr.microsoft.com. IP addresses and host:port forms are always blocked.

  Test: /v2/evil.com/... → 400.     /v2/1.2.3.4/... → 400.

  3. One file for all registry config:

  Registry info used to live in three places. Combined them into oci_registries.go — one list, three maps built from it. Adding a new registry is one line.

  Test: A small test makes sure every entry shows up in every map.

  4. Fix the trailing-slash bug:

  While testing, we found a global middleware adding / to every URL. This broke OCI calls because the spec doesn't allow trailing slashes. The middleware now skips /v2/ paths.

  Test: All seven registries return success end-to-end through the proxy.

  5. Validate path parameters:

  Image names, tags, and digests must now match the OCI spec format. Catches path traversal or short digests early.

  Test: ../../../etc/passwd in the URL → 400. Short digest → 400.

  6. Kill switch for the public proxy:

 Set DEPENDENCY_PROXY_OCI_PUBLIC_ENABLED=false to disable the public route entirely. Default leaves it on. Secret-scoped routes are unaffected.

 Test: With the env var set, public URL returns 404. Secret-scoped URLs still work.


  ---
  Order of checks at runtime

  1. Is the route registered? 
  2. Is the registry allowed? (
  3. Are the path params valid? 
  4. Cache hit? If not, call the upstream.
  5. If upstream returns 401, is the realm safe ?
  6. Get token, retry, return.

  How everything fits together at runtime

  Request → /v2/<registry>/<image-path>/<manifests|blobs|...>
              │
              ▼
      Route registered?              
              │
              ▼
      isAllowedRegistry(registry)    
              │
              ▼
      validateOCIPathParams(c)
	      │
              ▼
      Check cache / upstream call
              │
              ▼ (on 401)
      validateRealmHost(realm,host)  ← Gate 6 (the SSRF fix)
              │
              ▼
      fetchToken → retry → return

  Each layer fails fast with a clear 400 or 502 and never reaches the next.
