### PR TITLE
Respect LastAffected versions provided by OSV

### DIFF
--- a/dtos/osv_obj.go
+++ b/dtos/osv_obj.go
@@ -11,8 +11,9 @@ type Package struct {
 }
 
 type SemverEvent struct {
-	Introduced string `json:"introduced,omitempty"`
-	Fixed      string `json:"fixed,omitempty"`
+	Introduced   string `json:"introduced,omitempty"`
+	Fixed        string `json:"fixed,omitempty"`
+	LastAffected string `json:"last_affected,omitempty"`
 }
 
 type Range struct {

--- a/transformer/osv_transformer.go
+++ b/transformer/osv_transformer.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/dtos"
 	"github.com/l3montree-dev/devguard/normalize"
@@ -186,6 +187,15 @@ func processRanges(ranges []dtos.Range, ecosystem string, purl packageurl.Packag
 	return components
 }
 
+func incrementPatchVersion(version string) (string, error) {
+	v, err := semver.ParseTolerant(version)
+	if err != nil {
+		return "", err
+	}
+	v.Patch++
+	return v.String(), nil
+}
+
 func processRange(r dtos.Range, ecosystem string, purl packageurl.PackageURL) []models.AffectedComponent {
 	components := make([]models.AffectedComponent, 0, len(r.Events)/2+1)
 
@@ -194,6 +204,15 @@ func processRange(r dtos.Range, ecosystem string, purl packageurl.PackageURL) []
 		fixed := ""
 		if i+1 < len(r.Events) {
 			fixed = r.Events[i+1].Fixed
+			if fixed == "" && r.Events[i+1].LastAffected != "" {
+				incremented, err := incrementPatchVersion(r.Events[i+1].LastAffected)
+				if err != nil {
+					// non-semver last_affected — skip this range entry so the
+					// versions slice fallback in affectedComponentsFromAffected takes over
+					continue
+				}
+				fixed = incremented
+			}
 		}
 
 		var semverIntroduced, semverFixed, versionIntroduced, versionFixed *string

--- a/transformer/osv_transformer_test.go
+++ b/transformer/osv_transformer_test.go
@@ -1,0 +1,98 @@
+package transformer
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/l3montree-dev/devguard/dtos"
+)
+
+func TestNonSemverLastAffectedFallsBackToVersions(t *testing.T) {
+	osv := &dtos.OSV{
+		ID: "TEST-0001",
+		Affected: []dtos.Affected{
+			{
+				Package: dtos.Package{
+					Ecosystem: "Maven",
+					Purl:      "pkg:maven/org.example/lib",
+				},
+				Ranges: []dtos.Range{
+					{
+						Type: "ECOSYSTEM",
+						Events: []dtos.SemverEvent{
+							{Introduced: "4.5.0"},
+							{LastAffected: "4.6.0.Final"}, // non-semver: cannot be parsed
+						},
+					},
+				},
+				Versions: []string{"4.5.0", "4.5.1", "4.6.0"},
+			},
+		},
+	}
+
+	components := AffectedComponentsFromOSV(osv)
+
+	// range parsing must fail → falls back to the versions slice
+	if len(components) != 3 {
+		t.Fatalf("expected 3 version components from fallback, got %d", len(components))
+	}
+	for _, c := range components {
+		if c.Version == nil {
+			t.Errorf("expected exact version component, got range component")
+		}
+		if c.SemverIntroduced != nil || c.SemverFixed != nil {
+			t.Errorf("expected no semver range on fallback component")
+		}
+	}
+}
+
+func TestLastAffectedGetsRespected(t *testing.T) {
+	// read the test data
+	b, err := os.ReadFile("testdata/ghsa-jmp9-x22r-554x.json")
+	if err != nil {
+		t.Fatalf("failed to read test data: %v", err)
+	}
+
+	// unmarshal the test data
+	var osv dtos.OSV
+	if err := json.Unmarshal(b, &osv); err != nil {
+		t.Fatalf("failed to unmarshal test data: %v", err)
+	}
+
+	affectedComponents := AffectedComponentsFromOSV(&osv)
+	if len(affectedComponents) != 3 {
+		t.Fatalf("expected 3 affected component, got %d", len(affectedComponents))
+	}
+
+	// all purls should be the same - thats what we expect.
+	expectedRanges := [][]string{
+		{"6.2.0", "6.2.11"}, // this is a range with a fixed key
+		{"6.0.0", "6.1.23"}, // this is a last affected range, where we just increment the patch version by one to make sure it fits into our semver_fixed model
+		{"5.3.0", "5.3.45"}, // this again is a last affected range
+
+	}
+outer:
+	for _, c := range affectedComponents {
+		if c.PurlWithoutVersion != "pkg:maven/org.springframework/spring-core" {
+			t.Errorf("unexpected purl, got %s", c.PurlWithoutVersion)
+		}
+		// expect the semver versions exist
+		if c.SemverIntroduced == nil {
+			t.Errorf("expected semver introduced to be set, got nil")
+		}
+		if c.SemverFixed == nil {
+			t.Errorf("expected semver fixed to be set, got nil")
+		}
+
+		if c.SemverIntroduced != nil && c.SemverFixed != nil {
+			for _, r := range expectedRanges {
+				if *c.SemverIntroduced == r[0] && *c.SemverFixed == r[1] {
+					// this is what we expect, so we can continue with the next component
+					continue outer
+				}
+			}
+			t.Errorf("unexpected semver range: %s - %s", *c.SemverIntroduced, *c.SemverFixed)
+		}
+	}
+}

--- a/transformer/testdata/ghsa-jmp9-x22r-554x.json
+++ b/transformer/testdata/ghsa-jmp9-x22r-554x.json
@@ -1,0 +1,231 @@
+{
+    "id": "GHSA-jmp9-x22r-554x",
+    "summary": "Spring Framework annotation detection mechanism may result in improper authorization",
+    "details": "The Spring Framework annotation detection mechanism may not correctly resolve annotations on methods within type hierarchies with a parameterized super type with unbounded generics. This can be an issue if such annotations are used for authorization decisions.\n\nYour application may be affected by this if you are using Spring Security's @EnableMethodSecurity feature.\n\nYou are not affected by this if you are not using @EnableMethodSecurity or if you do not use security annotations on methods in generic superclasses or generic interfaces.\n\nThis CVE is published in conjunction with  CVE-2025-41248 https://spring.io/security/cve-2025-41248 .",
+    "aliases": [
+        "CVE-2025-41249"
+    ],
+    "modified": "2026-02-04T02:59:53.509459Z",
+    "published": "2025-09-16T15:32:34Z",
+    "related": [
+        "CGA-jv8r-5vrc-9287"
+    ],
+    "database_specific": {
+        "github_reviewed": true,
+        "nvd_published_at": "2025-09-16T11:15:30Z",
+        "cwe_ids": [
+            "CWE-285",
+            "CWE-863"
+        ],
+        "github_reviewed_at": "2025-09-16T19:38:20Z",
+        "severity": "HIGH"
+    },
+    "references": [
+        {
+            "type": "ADVISORY",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-41249"
+        },
+        {
+            "type": "WEB",
+            "url": "https://github.com/spring-projects/spring-framework/issues/35342"
+        },
+        {
+            "type": "WEB",
+            "url": "https://github.com/spring-projects/spring-framework/commit/6d710d482a6785b069e35022e81758953afc21ff"
+        },
+        {
+            "type": "PACKAGE",
+            "url": "https://github.com/spring-projects/spring-framework"
+        },
+        {
+            "type": "WEB",
+            "url": "https://github.com/spring-projects/spring-framework/releases/tag/v6.2.11"
+        },
+        {
+            "type": "WEB",
+            "url": "https://spring.io/security/cve-2025-41249"
+        }
+    ],
+    "affected": [
+        {
+            "package": {
+                "name": "org.springframework:spring-core",
+                "ecosystem": "Maven",
+                "purl": "pkg:maven/org.springframework/spring-core"
+            },
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {
+                            "introduced": "5.3.0"
+                        },
+                        {
+                            "last_affected": "5.3.44"
+                        }
+                    ]
+                }
+            ],
+            "versions": [
+                "5.3.0",
+                "5.3.1",
+                "5.3.10",
+                "5.3.11",
+                "5.3.12",
+                "5.3.13",
+                "5.3.14",
+                "5.3.15",
+                "5.3.16",
+                "5.3.17",
+                "5.3.18",
+                "5.3.19",
+                "5.3.2",
+                "5.3.20",
+                "5.3.21",
+                "5.3.22",
+                "5.3.23",
+                "5.3.24",
+                "5.3.25",
+                "5.3.26",
+                "5.3.27",
+                "5.3.28",
+                "5.3.29",
+                "5.3.3",
+                "5.3.30",
+                "5.3.31",
+                "5.3.32",
+                "5.3.33",
+                "5.3.34",
+                "5.3.35",
+                "5.3.36",
+                "5.3.37",
+                "5.3.38",
+                "5.3.39",
+                "5.3.4",
+                "5.3.5",
+                "5.3.6",
+                "5.3.7",
+                "5.3.8",
+                "5.3.9"
+            ],
+            "database_specific": {
+                "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2025/09/GHSA-jmp9-x22r-554x/GHSA-jmp9-x22r-554x.json"
+            }
+        },
+        {
+            "package": {
+                "name": "org.springframework:spring-core",
+                "ecosystem": "Maven",
+                "purl": "pkg:maven/org.springframework/spring-core"
+            },
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {
+                            "introduced": "6.0.0"
+                        },
+                        {
+                            "last_affected": "6.1.22"
+                        }
+                    ]
+                }
+            ],
+            "versions": [
+                "6.0.0",
+                "6.0.1",
+                "6.0.10",
+                "6.0.11",
+                "6.0.12",
+                "6.0.13",
+                "6.0.14",
+                "6.0.15",
+                "6.0.16",
+                "6.0.17",
+                "6.0.18",
+                "6.0.19",
+                "6.0.2",
+                "6.0.20",
+                "6.0.21",
+                "6.0.22",
+                "6.0.23",
+                "6.0.3",
+                "6.0.4",
+                "6.0.5",
+                "6.0.6",
+                "6.0.7",
+                "6.0.8",
+                "6.0.9",
+                "6.1.0",
+                "6.1.1",
+                "6.1.10",
+                "6.1.11",
+                "6.1.12",
+                "6.1.13",
+                "6.1.14",
+                "6.1.15",
+                "6.1.16",
+                "6.1.17",
+                "6.1.18",
+                "6.1.19",
+                "6.1.2",
+                "6.1.20",
+                "6.1.21",
+                "6.1.3",
+                "6.1.4",
+                "6.1.5",
+                "6.1.6",
+                "6.1.7",
+                "6.1.8",
+                "6.1.9"
+            ],
+            "database_specific": {
+                "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2025/09/GHSA-jmp9-x22r-554x/GHSA-jmp9-x22r-554x.json"
+            }
+        },
+        {
+            "package": {
+                "name": "org.springframework:spring-core",
+                "ecosystem": "Maven",
+                "purl": "pkg:maven/org.springframework/spring-core"
+            },
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {
+                            "introduced": "6.2.0"
+                        },
+                        {
+                            "fixed": "6.2.11"
+                        }
+                    ]
+                }
+            ],
+            "versions": [
+                "6.2.0",
+                "6.2.1",
+                "6.2.10",
+                "6.2.2",
+                "6.2.3",
+                "6.2.4",
+                "6.2.5",
+                "6.2.6",
+                "6.2.7",
+                "6.2.8",
+                "6.2.9"
+            ],
+            "database_specific": {
+                "last_known_affected_version_range": "\u003c= 6.2.10",
+                "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2025/09/GHSA-jmp9-x22r-554x/GHSA-jmp9-x22r-554x.json"
+            }
+        }
+    ],
+    "schema_version": "1.7.3",
+    "severity": [
+        {
+            "type": "CVSS_V3",
+            "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds LastAffected version parsing from osv. It will increment the parsed version by one patch version to fit inside the semver_fixed column. 