### PR TITLE
Returning specific reauthorize error if token is invalid, using status code

### DIFF
--- a/integrations/gitlabint/gitlab_integration.go
+++ b/integrations/gitlabint/gitlab_integration.go
@@ -232,7 +232,7 @@ func (g *GitlabIntegration) HasAccessToExternalEntityProvider(ctx shared.Context
 	// check that the token is valid
 	if !g.checkIfTokenIsValid(ctx, *token, 0) {
 		slog.Error("gitlab oauth2 token is not valid", "providerID", externalEntityProviderID)
-		return false, fmt.Errorf("gitlab oauth2 token is not valid for provider %s", externalEntityProviderID)
+		return false, shared.ErrOauth2TokenNotValidRedirectionRequired
 	}
 
 	return true, nil

--- a/middlewares/access_control_middlewares.go
+++ b/middlewares/access_control_middlewares.go
@@ -16,6 +16,7 @@
 package middlewares
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -239,6 +240,10 @@ func MultiOrganizationMiddlewareRBAC(rbacProvider shared.RBACProvider, organizat
 			session := shared.GetSession(ctx)
 			allowed, err := domainRBAC.HasAccess(ctx.Request().Context(), session.GetUserID())
 			if err != nil {
+				if errors.Is(err, shared.ErrOauth2TokenNotValidRedirectionRequired) {
+					slog.Info("oauth2 token not valid, asking user to reauthorize", "user", session.GetUserID(), "organization", organization)
+					return ctx.JSON(403, map[string]string{"error": "oauth2 token not valid, please reauthorize"})
+				}
 				if org.IsPublic {
 					shared.SetIsPublicRequest(ctx)
 					shared.SetOrg(ctx, *org)
@@ -246,7 +251,6 @@ func MultiOrganizationMiddlewareRBAC(rbacProvider shared.RBACProvider, organizat
 					shared.SetOrgSlug(ctx, organization)
 					return next(ctx)
 				}
-				slog.Info("asking user to reauthorize", "err", err)
 				return ctx.JSON(401, map[string]string{"error": err.Error()})
 			}
 

--- a/middlewares/access_control_test.go
+++ b/middlewares/access_control_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/l3montree-dev/devguard/accesscontrol"
 	"github.com/l3montree-dev/devguard/database/models"
+	"github.com/l3montree-dev/devguard/integrations/gitlabint"
 	"github.com/l3montree-dev/devguard/mocks"
 	"github.com/l3montree-dev/devguard/shared"
 	"github.com/labstack/echo/v4"
@@ -528,6 +529,79 @@ func TestAssetAccessControl(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, httpErr.Code)
 		mockRBAC.AssertExpectations(t)
 		mockAssetRepo.AssertExpectations(t)
+	})
+}
+
+// TestMultiOrganizationMiddlewareRBAC tests the MultiOrganizationMiddlewareRBAC middleware
+func TestMultiOrganizationMiddlewareRBAC(t *testing.T) {
+	t.Run("returns 403 when oauth2 token is not valid", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("organization")
+		ctx.SetParamValues("test-org")
+
+		orgID := uuid.New()
+		org := &models.Org{Model: models.Model{ID: orgID}, Slug: "test-org"}
+
+		mockRBACProvider := mocks.RBACProvider{}
+		mockOrgService := mocks.OrgService{}
+		mockAccessControl := mocks.AccessControl{}
+		mockSession := accesscontrol.NewSession("user-id", []string{})
+
+		mockOrgService.On("ReadBySlug", mock.Anything, "test-org").Return(org, nil)
+		mockRBACProvider.On("GetDomainRBAC", orgID.String()).Return(&mockAccessControl)
+		mockAccessControl.On("HasAccess", mock.Anything, "user-id").Return(false, shared.ErrOauth2TokenNotValidRedirectionRequired)
+
+		ctx.Set("session", mockSession)
+
+		middleware := MultiOrganizationMiddlewareRBAC(&mockRBACProvider, &mockOrgService, map[string]*gitlabint.GitlabOauth2Config{})
+
+		err := middleware(func(ctx shared.Context) error {
+			return ctx.JSON(http.StatusOK, "success")
+		})(ctx)
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		mockOrgService.AssertExpectations(t)
+		mockRBACProvider.AssertExpectations(t)
+		mockAccessControl.AssertExpectations(t)
+	})
+
+	t.Run("returns 401 for generic HasAccess error on private org", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("organization")
+		ctx.SetParamValues("test-org")
+
+		orgID := uuid.New()
+		org := &models.Org{Model: models.Model{ID: orgID}, Slug: "test-org"}
+
+		mockRBACProvider := mocks.RBACProvider{}
+		mockOrgService := mocks.OrgService{}
+		mockAccessControl := mocks.AccessControl{}
+		mockSession := accesscontrol.NewSession("user-id", []string{})
+
+		mockOrgService.On("ReadBySlug", mock.Anything, "test-org").Return(org, nil)
+		mockRBACProvider.On("GetDomainRBAC", orgID.String()).Return(&mockAccessControl)
+		mockAccessControl.On("HasAccess", mock.Anything, "user-id").Return(false, errors.New("some auth error"))
+
+		ctx.Set("session", mockSession)
+
+		middleware := MultiOrganizationMiddlewareRBAC(&mockRBACProvider, &mockOrgService, map[string]*gitlabint.GitlabOauth2Config{})
+
+		err := middleware(func(ctx shared.Context) error {
+			return ctx.JSON(http.StatusOK, "success")
+		})(ctx)
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		mockOrgService.AssertExpectations(t)
+		mockRBACProvider.AssertExpectations(t)
+		mockAccessControl.AssertExpectations(t)
 	})
 }
 

--- a/shared/thirdparty_integration.go
+++ b/shared/thirdparty_integration.go
@@ -18,6 +18,8 @@ const (
 	WebhookIntegrationID IntegrationID = "webhook"
 )
 
+var ErrOauth2TokenNotValidRedirectionRequired = fmt.Errorf("oauth2 token not valid, redirection required")
+
 type ThirdPartyIntegration interface {
 	WantsToHandleWebhook(ctx Context) bool
 	HandleWebhook(ctx Context) error


### PR DESCRIPTION
This PR introduces an explicit status code if the oauth2 token of a user is invalid.