### PR TITLE
Add purl validation to purl inspect

### DIFF
--- a/controllers/external_reference_controller.go
+++ b/controllers/external_reference_controller.go
@@ -134,8 +134,12 @@ func (c *ExternalReferenceController) Create(ctx shared.Context) error {
 		if req.CSAFPackageScope == "" {
 			return echo.NewHTTPError(400, "csafPackageScope is required for csaf references")
 		}
-		if _, err := packageurl.FromString(req.CSAFPackageScope); err != nil {
+		purl, err := packageurl.FromString(req.CSAFPackageScope)
+		if err != nil {
 			return echo.NewHTTPError(400, "csafPackageScope must be a valid PURL").WithInternal(err)
+		}
+		if err := utils.ValidatePurlFields(purl); err != nil {
+			return echo.NewHTTPError(400, "csafPackageScope PURL contains invalid characters").WithInternal(err)
 		}
 	}
 

--- a/controllers/vulndb_controller.go
+++ b/controllers/vulndb_controller.go
@@ -135,9 +135,15 @@ func (c VulnDBController) PURLInspect(ctx shared.Context) error {
 	//delete the last slash if exists
 	purlString = strings.TrimSuffix(purlString, "/")
 
+	// validate the purl structure first
 	purl, err := packageurl.FromString(purlString)
 	if err != nil {
-		return echo.NewHTTPError(400, "invalid PURL").WithInternal(err)
+		return echo.NewHTTPError(400, "invalid PURL format").WithInternal(err)
+	}
+
+	// then validate the individual fields as well
+	if err := utils.ValidatePurlFields(purl); err != nil {
+		return echo.NewHTTPError(400, "PURL contains invalid characters").WithInternal(err)
 	}
 
 	matchCtx := normalize.ParsePurlForMatching(purl)

--- a/utils/common.go
+++ b/utils/common.go
@@ -16,12 +16,15 @@
 package utils
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
+
+	"github.com/package-url/packageurl-go"
 )
 
 // we use Set 1 of ISO 639 language codes to identify languages based on 2 letters
@@ -183,4 +186,29 @@ func CheckIfDeleted(name string) bool {
 // checks if a given string is a valid CVE
 func IsCVE(str string) bool {
 	return regexp.MustCompile("^CVE-[0-9]{4}-[0-9]{4,}$").MatchString(str)
+}
+
+// allowed character per purl field
+var (
+	purlTypeRe      = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9.+-]*$`)
+	purlNamespaceRe = regexp.MustCompile(`^[a-zA-Z0-9._~@-]+(/[a-zA-Z0-9._~@-]+)*$`)
+	purlNameRe      = regexp.MustCompile(`^[a-zA-Z0-9._~@+-]+$`)
+	purlVersionRe   = regexp.MustCompile(`^[a-zA-Z0-9._~:!+,@-]+$`)
+)
+
+// validate individual fields of purl for any incorrect characters
+func ValidatePurlFields(purl packageurl.PackageURL) error {
+	if !purlTypeRe.MatchString(purl.Type) {
+		return fmt.Errorf("invalid purl type: %q", purl.Type)
+	}
+	if purl.Namespace != "" && !purlNamespaceRe.MatchString(purl.Namespace) {
+		return fmt.Errorf("invalid purl namespace: %q", purl.Namespace)
+	}
+	if !purlNameRe.MatchString(purl.Name) {
+		return fmt.Errorf("invalid purl name: %q", purl.Name)
+	}
+	if purl.Version != "" && !purlVersionRe.MatchString(purl.Version) {
+		return fmt.Errorf("invalid purl version: %q", purl.Version)
+	}
+	return nil
 }


### PR DESCRIPTION
From string parses only the structure of a valid purl but does not check any (decoded) values of the individual fields.

To solve this I added a helper function to common.go where each fields gets checked for only valid characters and integrated the check into 2 exposed endpoints requiring (parsed) purls.