### PR TITLE
add frameworkContains filter and sort open compliance risks first

### DIFF
--- a/database/repositories/compliance_risk_repository.go
+++ b/database/repositories/compliance_risk_repository.go
@@ -52,7 +52,16 @@ func (r *ComplianceRiskRepository) GetAllComplianceRisksForAssetVersionPaged(ctx
 		return shared.Paged[models.ComplianceRisk]{}, err
 	}
 
-	err := q.Limit(pageInfo.PageSize).Offset((pageInfo.Page - 1) * pageInfo.PageSize).Find(&risks).Error
+	// Order open risks first, then newest. The open-first key is selected as an
+	// aliased column because the query uses SELECT DISTINCT (Postgres requires
+	// ORDER BY expressions to appear in the select list). Per-column sort is not
+	// yet supported server-side (the sort param is ignored).
+	err := q.
+		Select("compliance_risks.*, CASE WHEN compliance_risks.state = 'open' THEN 0 ELSE 1 END AS state_sort_order").
+		Order("state_sort_order ASC").
+		Order("compliance_risks.created_at DESC").
+		Limit(pageInfo.PageSize).Offset((pageInfo.Page - 1) * pageInfo.PageSize).
+		Find(&risks).Error
 	if err != nil {
 		return shared.Paged[models.ComplianceRisk]{}, err
 	}

--- a/database/repositories/compliance_risk_repository.go
+++ b/database/repositories/compliance_risk_repository.go
@@ -52,16 +52,7 @@ func (r *ComplianceRiskRepository) GetAllComplianceRisksForAssetVersionPaged(ctx
 		return shared.Paged[models.ComplianceRisk]{}, err
 	}
 
-	// Order open risks first, then newest. The open-first key is selected as an
-	// aliased column because the query uses SELECT DISTINCT (Postgres requires
-	// ORDER BY expressions to appear in the select list). Per-column sort is not
-	// yet supported server-side (the sort param is ignored).
-	err := q.
-		Select("compliance_risks.*, CASE WHEN compliance_risks.state = 'open' THEN 0 ELSE 1 END AS state_sort_order").
-		Order("state_sort_order ASC").
-		Order("compliance_risks.created_at DESC").
-		Limit(pageInfo.PageSize).Offset((pageInfo.Page - 1) * pageInfo.PageSize).
-		Find(&risks).Error
+	err := q.Limit(pageInfo.PageSize).Offset((pageInfo.Page - 1) * pageInfo.PageSize).Find(&risks).Error
 	if err != nil {
 		return shared.Paged[models.ComplianceRisk]{}, err
 	}

--- a/shared/context_utils.go
+++ b/shared/context_utils.go
@@ -574,6 +574,11 @@ func (f FilterQuery) SQL() string {
 		return field + " ILIKE ?"
 	case "any":
 		return "? = ANY(string_to_array(" + field + ", ' '))"
+	case "frameworkContains":
+		// Matches a JSONB array-of-objects column (e.g. policyFrameworks) where any
+		// element's "framework" key equals the value. Used by the compliance-risks
+		// framework filter.
+		return "EXISTS (SELECT 1 FROM jsonb_array_elements(" + field + ") AS e WHERE e->>'framework' = ?)"
 	default:
 		// default do an equals
 		return field + " = ?"


### PR DESCRIPTION
### What changed
Add `frameworkContains` filter operator that matches any element's framework key in a JSONB array-of-objects column
Order compliance risk results so open risks appear before closed ones, then by newest first