### PR TITLE
feat: add artifact-scoped badge route

### DIFF
--- a/router/artifact_router.go
+++ b/router/artifact_router.go
@@ -29,6 +29,7 @@ type ArtifactRouter struct {
 func NewArtifactRouter(
 	assetVersionGroup AssetVersionRouter,
 	artifactController *controllers.ArtifactController,
+	assetController *controllers.AssetController,
 	externalReferenceController *controllers.ExternalReferenceController,
 	artifactRepository shared.ArtifactRepository,
 	assetRepository shared.AssetRepository,
@@ -43,6 +44,7 @@ func NewArtifactRouter(
 	artifactRouter.GET("/vex.xml/", artifactController.VEXXML)
 	artifactRouter.GET("/sbom.pdf/", artifactController.BuildPDFFromSBOM)
 	artifactRouter.GET("/vulnerability-report.pdf/", artifactController.BuildVulnerabilityReportPDF)
+	artifactRouter.GET("/badges/:badge/", assetController.GetBadges)
 
 	artifactRouter.DELETE("/", artifactController.DeleteArtifact, middlewares.NeededScope([]string{"manage"}), assetScopedRBAC(shared.ObjectAsset, shared.ActionUpdate))
 	artifactRouter.PUT("/", artifactController.UpdateArtifact, middlewares.NeededScope([]string{"manage"}), assetScopedRBAC(shared.ObjectAsset, shared.ActionUpdate))

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -283,7 +283,7 @@ func buildSecurityTestServer(t *testing.T, ac *mocks.AccessControl) *echo.Echo {
 	NewFirstPartyVulnRouter(assetVersionRouter, new(controllers.FirstPartyVulnController), new(controllers.VulnEventController))
 	NewLicenseRiskRouter(assetVersionRouter, new(controllers.LicenseRiskController))
 	NewVEXRuleRouter(assetVersionRouter, new(controllers.VEXRuleController))
-	NewArtifactRouter(assetVersionRouter, new(controllers.ArtifactController), new(controllers.ExternalReferenceController), artifactRepo, assetRepo)
+	NewArtifactRouter(assetVersionRouter, new(controllers.ArtifactController), new(controllers.AssetController), new(controllers.ExternalReferenceController), artifactRepo, assetRepo)
 	NewExternalReferenceRouter(assetVersionRouter, new(controllers.ExternalReferenceController), assetRepo)
 
 	return e


### PR DESCRIPTION
## Problem

Fixes #2198

The CVSS badge shown in the "Enable public access to vulnerability data" dialog does not reflect the selected branch/tag and artifact.

Root cause on the API side: the only authenticated badge endpoint is asset-scoped (`GET .../assets/:assetSlug/badges/:badge/`). `GetBadges` then falls back to the default asset version with `artifactName = nil`, and `GetLatestRiskHistory` picks a single arbitrary artifact row (`ORDER BY day DESC LIMIT 1`) — so the badge shows values of a random artifact instead of the selected one.

## Change

Expose the badge endpoint on the authenticated artifact router as well:

```
GET .../refs/:assetVersionSlug/artifacts/:artifactName/badges/:badge/
```

`AssetVersionMiddleware` and `ArtifactMiddleware` already put version and artifact into the context, and `GetBadges` already supports artifact scoping (it is used by the public share router this way), so the route addition is enough. The artifact-scoped controller behavior is covered by the existing test in `asset_controller_test.go` ("uses artifact-scoped latest snapshot when artifact is in context").

The badge preview in devguard-web needs a follow-up PR to load the badge from this scoped endpoint based on the selected ref/artifact — happy to open that as well.

## Note for maintainers

The asset-level badge (no artifact in scope) still returns an arbitrary artifact's latest row rather than an aggregate across artifacts. If an aggregated asset-level badge is desired, that would be a separate change in `GetLatestRiskHistory`.