### PR TITLE
feat: cache cve-ecosystem-distribution endpoint

### DIFF
--- a/controllers/vulndb_controller.go
+++ b/controllers/vulndb_controller.go
@@ -1,10 +1,12 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/l3montree-dev/devguard/config"
@@ -19,6 +21,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/package-url/packageurl-go"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
 	"gorm.io/gorm"
 )
 
@@ -30,6 +33,9 @@ type VulnDBController struct {
 	componentService            shared.ComponentService
 	fixedVersionResolver        shared.FixedVersionResolver
 	dependencyVulnRepository    shared.DependencyVulnRepository
+
+	// pointer, so the value-receiver methods share one cache instead of copying the lock
+	ecosystemDistributionCache *ecosystemDistributionCache
 }
 
 func NewVulnDBController(cveRepository shared.CveRepository, maliciousPackageChecker shared.MaliciousPackageChecker, affectedComponentRepository shared.AffectedComponentRepository, componentRepository shared.ComponentRepository, componentService shared.ComponentService, fixedVersionResolver shared.FixedVersionResolver, dependencyVulnRepository shared.DependencyVulnRepository) *VulnDBController {
@@ -41,6 +47,7 @@ func NewVulnDBController(cveRepository shared.CveRepository, maliciousPackageChe
 		componentService:            componentService,
 		fixedVersionResolver:        fixedVersionResolver,
 		dependencyVulnRepository:    dependencyVulnRepository,
+		ecosystemDistributionCache:  &ecosystemDistributionCache{},
 	}
 }
 
@@ -259,8 +266,62 @@ type ecosystemRow struct {
 	Count     int    `gorm:"count" json:"count"`
 }
 
+// the distribution aggregates the whole global vuln db (no org/user/request dimension),
+// only changes when the vulndb mirror runs (~hourly) and is expensive to compute (15-20s),
+// so a single cached value with a long TTL is safe
+const ecosystemDistributionExpiryTime = 1 * time.Hour
+
+type ecosystemDistributionCache struct {
+	mutex      sync.RWMutex
+	group      singleflight.Group
+	value      map[string]int
+	expiryTime time.Time
+}
+
+// nosemgrep: service-method-missing-ctx -- private in-memory cache helper; no I/O
+func (c *ecosystemDistributionCache) get() (map[string]int, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	if c.value == nil || c.expiryTime.Before(time.Now()) {
+		return nil, false
+	}
+	return c.value, true
+}
+
+// nosemgrep: service-method-missing-ctx -- private in-memory cache helper; no I/O
+func (c *ecosystemDistributionCache) set(value map[string]int) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.value = value
+	c.expiryTime = time.Now().Add(ecosystemDistributionExpiryTime)
+}
+
 // return the number of vulnerabilities in affected packages per ecosystem
 func (c VulnDBController) GetCVEEcosystemDistribution(ctx shared.Context) error {
+	if distribution, found := c.ecosystemDistributionCache.get(); found {
+		return ctx.JSONPretty(200, distribution, config.PrettyJSONIndent)
+	}
+
+	// use singleflight to avoid concurrent recomputations of the expensive aggregation
+	result, err, _ := c.ecosystemDistributionCache.group.Do("cve-ecosystem-distribution", func() (any, error) {
+		if distribution, found := c.ecosystemDistributionCache.get(); found {
+			return distribution, nil
+		}
+		distribution, err := c.computeCVEEcosystemDistribution(ctx.Request().Context())
+		if err != nil {
+			return nil, err
+		}
+		c.ecosystemDistributionCache.set(distribution)
+		return distribution, nil
+	})
+	if err != nil {
+		return echo.NewHTTPError(500, "could not fetch data from database").WithInternal(err)
+	}
+
+	return ctx.JSONPretty(200, result.(map[string]int), config.PrettyJSONIndent)
+}
+
+func (c VulnDBController) computeCVEEcosystemDistribution(ctx context.Context) (map[string]int, error) {
 	cveResults := make([]ecosystemRow, 0, 1024)
 	maliciousPackageResults := make([]ecosystemRow, 0, 64)
 
@@ -268,18 +329,18 @@ func (c VulnDBController) GetCVEEcosystemDistribution(ctx shared.Context) error 
 	cveSQL := `SELECT LOWER(b.ecosystem) as ecosystem, COUNT(DISTINCT a.cve_id) FROM cve_affected_component a
 	LEFT JOIN affected_components b ON b.id = a.affected_component_id
 	GROUP BY LOWER(b.ecosystem);`
-	err := c.affectedComponentRepository.GetDB(ctx.Request().Context(), nil).Raw(cveSQL).Find(&cveResults).Error
+	err := c.affectedComponentRepository.GetDB(ctx, nil).Raw(cveSQL).Find(&cveResults).Error
 	if err != nil {
-		return echo.NewHTTPError(500, "could not fetch data from database").WithInternal(err)
+		return nil, err
 	}
 
 	// do the same thing for malicious packages
-	maliciousPackagesSQL := `SELECT LOWER(b.ecosystem) as ecosystem, COUNT(*) FROM malicious_packages a 
-	LEFT JOIN malicious_affected_components b ON a.id = b.malicious_package_id 
+	maliciousPackagesSQL := `SELECT LOWER(b.ecosystem) as ecosystem, COUNT(*) FROM malicious_packages a
+	LEFT JOIN malicious_affected_components b ON a.id = b.malicious_package_id
 	GROUP BY LOWER(b.ecosystem);`
-	err = c.affectedComponentRepository.GetDB(ctx.Request().Context(), nil).Raw(maliciousPackagesSQL).Find(&maliciousPackageResults).Error
+	err = c.affectedComponentRepository.GetDB(ctx, nil).Raw(maliciousPackagesSQL).Find(&maliciousPackageResults).Error
 	if err != nil {
-		return echo.NewHTTPError(500, "could not fetch data from database").WithInternal(err)
+		return nil, err
 	}
 
 	// group the results in a map by cutting the ecosystem identifier before the ':'
@@ -289,6 +350,5 @@ func (c VulnDBController) GetCVEEcosystemDistribution(ctx shared.Context) error 
 		ecosystemToAmount[key] += row.Count
 	}
 
-	// convert the result in a map and return it
-	return ctx.JSONPretty(200, ecosystemToAmount, config.PrettyJSONIndent)
+	return ecosystemToAmount, nil
 }

--- a/controllers/vulndb_controller_test.go
+++ b/controllers/vulndb_controller_test.go
@@ -1,0 +1,65 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEcosystemDistributionCache(t *testing.T) {
+	t.Run("returns nothing when empty", func(t *testing.T) {
+		cache := &ecosystemDistributionCache{}
+
+		_, found := cache.get()
+
+		assert.False(t, found)
+	})
+
+	t.Run("returns the cached value before expiry", func(t *testing.T) {
+		cache := &ecosystemDistributionCache{}
+		cache.set(map[string]int{"golang": 42, "npm": 7})
+
+		value, found := cache.get()
+
+		assert.True(t, found)
+		assert.Equal(t, map[string]int{"golang": 42, "npm": 7}, value)
+	})
+
+	t.Run("returns nothing after expiry", func(t *testing.T) {
+		cache := &ecosystemDistributionCache{}
+		cache.set(map[string]int{"golang": 42})
+		cache.expiryTime = time.Now().Add(-time.Second)
+
+		_, found := cache.get()
+
+		assert.False(t, found)
+	})
+}
+
+func TestGetCVEEcosystemDistributionServesFromCache(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	// the repository stays nil - any database access would panic, which proves
+	// a cache hit never touches the database
+	controller := &VulnDBController{
+		ecosystemDistributionCache: &ecosystemDistributionCache{},
+	}
+	controller.ecosystemDistributionCache.set(map[string]int{"golang": 42, "npm": 7})
+
+	err := controller.GetCVEEcosystemDistribution(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]int
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, map[string]int{"golang": 42, "npm": 7}, body)
+}

--- a/tests/fx_test_app.go
+++ b/tests/fx_test_app.go
@@ -78,6 +78,7 @@ type TestApp struct {
 	VEXRuleController           *controllers.VEXRuleController
 	ExternalReferenceController *controllers.ExternalReferenceController
 	StatisticsController        *controllers.StatisticsController
+	VulnDBController            *controllers.VulnDBController
 
 	// Repositories
 	AssetRepository             shared.AssetRepository

--- a/tests/vulndb_controller_integration_test.go
+++ b/tests/vulndb_controller_integration_test.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/l3montree-dev/devguard/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCVEEcosystemDistribution(t *testing.T) {
+	t.Parallel()
+	db, pool, terminate := InitDatabaseContainer("../initdb.sql")
+	defer terminate()
+
+	app, _ := NewTestAppWithT(t, db, pool, nil)
+
+	// two CVEs sharing one golang component and one CVE in an npm component
+	cveA := models.CVE{CVE: "CVE-2026-11111", DatePublished: time.Now(), DateLastModified: time.Now()}
+	cveB := models.CVE{CVE: "CVE-2026-22222", DatePublished: time.Now(), DateLastModified: time.Now()}
+	cveC := models.CVE{CVE: "CVE-2026-33333", DatePublished: time.Now(), DateLastModified: time.Now()}
+	require.NoError(t, db.Create(&[]models.CVE{cveA, cveB, cveC}).Error)
+
+	golangComponent := models.AffectedComponent{
+		Ecosystem: "Golang",
+		CVE:       []models.CVE{cveA, cveB},
+	}
+	npmComponent := models.AffectedComponent{
+		Ecosystem: "npm",
+		CVE:       []models.CVE{cveC},
+	}
+	require.NoError(t, db.Create(&golangComponent).Error)
+	require.NoError(t, db.Create(&npmComponent).Error)
+
+	// one malicious npm package
+	maliciousPackage := models.MaliciousPackage{ID: "MAL-2026-0001"}
+	require.NoError(t, db.Create(&maliciousPackage).Error)
+	require.NoError(t, db.Create(&models.MaliciousAffectedComponent{
+		MaliciousPackageID: maliciousPackage.ID,
+		Ecosystem:          "npm",
+	}).Error)
+
+	callEndpoint := func() map[string]int {
+		rec := httptest.NewRecorder()
+		ctx := NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+		require.NoError(t, app.VulnDBController.GetCVEEcosystemDistribution(ctx))
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var body map[string]int
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		return body
+	}
+
+	t.Run("computes the distribution per ecosystem", func(t *testing.T) {
+		// 2 distinct CVEs in golang (lowercased), 1 CVE + 1 malicious package in npm
+		assert.Equal(t, map[string]int{"golang": 2, "npm": 2}, callEndpoint())
+	})
+
+	t.Run("serves the cached value on subsequent calls", func(t *testing.T) {
+		newComponent := models.AffectedComponent{
+			Ecosystem: "pypi",
+			CVE:       []models.CVE{cveA},
+		}
+		require.NoError(t, db.Create(&newComponent).Error)
+
+		// the new pypi component must not show up yet - the first call cached the result
+		assert.Equal(t, map[string]int{"golang": 2, "npm": 2}, callEndpoint())
+	})
+}


### PR DESCRIPTION
## Summary

The `/api/v1/vulndb/cve-ecosystem-distribution/` endpoint takes 15-20s per request because it aggregates the whole global vuln db every time (`COUNT(DISTINCT cve_id)` over the full `cve_affected_component` join table).

The data only changes when the vulndb mirror runs (~hourly) and has no org/user/request dimension, so this adds a single in-process cached value with a 1h TTL and `singleflight` to prevent concurrent recomputations — the same pattern already used for the org statistics cache in `statistics_service.go`. The query logic itself is unchanged, just extracted into `computeCVEEcosystemDistribution`.

The cache hangs off the controller as a pointer so the existing value-receiver methods don't copy the lock.

## Tests

- Unit tests for the cache (empty/valid/expired) and proof that a cache hit never touches the database
- Integration test against a real Postgres (testcontainers): correct distribution incl. ecosystem lowercasing and merging of CVE + malicious package counts, and that a second call is served from cache
- `VulnDBController` was added to the fx `TestApp` wiring for this

Closes #2222