### PR TITLE
Fail health check when PostgreSQL listener disconnects

### DIFF
--- a/database/postgresql_broker.go
+++ b/database/postgresql_broker.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -57,8 +58,9 @@ type PostgreSQLBroker struct {
 	subscribers              map[shared.PubSubChannel]ListeningConnection
 	subscribeMux             sync.RWMutex
 	wg                       sync.WaitGroup
-	ID                       string // Unique identifier for the broker instance
-	shouldReceiveOwnMessages bool   // Flag to control whether to receive own messages
+	ID                       string      // Unique identifier for the broker instance
+	shouldReceiveOwnMessages bool        // Flag to control whether to receive own messages
+	listenerFailed           atomic.Bool // Set by a listener goroutine when its connection fails.
 }
 
 func (b *PostgreSQLBroker) SetShouldReceiveOwnMessages(should bool) {
@@ -170,6 +172,7 @@ func (b *PostgreSQLBroker) processMessages(topic shared.PubSubChannel, conn *pgx
 	for {
 		notification, err := conn.Conn().WaitForNotification(context.TODO())
 		if err != nil {
+			b.listenerFailed.Store(true)
 			conn.Release()
 			monitoring.Alert("could not listen for notifications from PostgreSQL broker", err)
 			return
@@ -214,20 +217,7 @@ func (b *PostgreSQLBroker) processMessages(topic shared.PubSubChannel, conn *pgx
 
 // IsHealthy checks if the broker is functioning properly
 func (b *PostgreSQLBroker) IsHealthy() bool {
-	// check if all listening connections are still alive
-	b.subscribeMux.RLock()
-	defer b.subscribeMux.RUnlock()
-
-	for topic, listeningConn := range b.subscribers {
-		ctx := context.Background()
-		ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-		if err := listeningConn.Conn.Ping(ctxWithTimeout); err != nil {
-			slog.Error("listening connection is not healthy", "topic", topic, "error", err)
-			return false
-		}
-	}
-	return true
+	return !b.listenerFailed.Load()
 }
 
 // GetActiveTopics returns a list of topics currently being listened to

--- a/mocks/mock_PubSubBroker.go
+++ b/mocks/mock_PubSubBroker.go
@@ -38,6 +38,50 @@ func (_m *PubSubBroker) EXPECT() *PubSubBroker_Expecter {
 	return &PubSubBroker_Expecter{mock: &_m.Mock}
 }
 
+// IsHealthy provides a mock function for the type PubSubBroker
+func (_mock *PubSubBroker) IsHealthy() bool {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsHealthy")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// PubSubBroker_IsHealthy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsHealthy'
+type PubSubBroker_IsHealthy_Call struct {
+	*mock.Call
+}
+
+// IsHealthy is a helper method to define mock.On call
+func (_e *PubSubBroker_Expecter) IsHealthy() *PubSubBroker_IsHealthy_Call {
+	return &PubSubBroker_IsHealthy_Call{Call: _e.mock.On("IsHealthy")}
+}
+
+func (_c *PubSubBroker_IsHealthy_Call) Run(run func()) *PubSubBroker_IsHealthy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PubSubBroker_IsHealthy_Call) Return(b bool) *PubSubBroker_IsHealthy_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *PubSubBroker_IsHealthy_Call) RunAndReturn(run func() bool) *PubSubBroker_IsHealthy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Publish provides a mock function for the type PubSubBroker
 func (_mock *PubSubBroker) Publish(ctx context.Context, message shared.PubSubMessage) error {
 	ret := _mock.Called(ctx, message)

--- a/router/apiv1_router.go
+++ b/router/apiv1_router.go
@@ -42,6 +42,7 @@ type APIV1Router struct {
 func NewAPIV1Router(srv api.Server,
 	db shared.DB,
 	pool *pgxpool.Pool,
+	broker shared.PubSubBroker,
 	thirdPartyIntegration shared.IntegrationAggregate,
 	oryAdmin shared.AdminClient,
 	configService shared.ConfigService,
@@ -257,6 +258,14 @@ func NewAPIV1Router(srv api.Server,
 			return ctx.JSON(503, map[string]string{
 				"status": "unhealthy",
 				"error":  "database ping failed",
+			})
+		}
+
+		if !broker.IsHealthy() {
+			slog.Info("database pub/sub connection is unhealthy")
+			return ctx.JSON(503, map[string]string{
+				"status": "unhealthy",
+				"error":  "database pub/sub connection failed",
 			})
 		}
 

--- a/shared/pubsub.go
+++ b/shared/pubsub.go
@@ -30,6 +30,7 @@ type PubSubMessage interface {
 type PubSubBroker interface {
 	Publish(ctx context.Context, message PubSubMessage) error
 	Subscribe(topic PubSubChannel) (<-chan map[string]any, error)
+	IsHealthy() bool
 }
 
 type SimpleMessage struct {

--- a/tests/fx_test_app.go
+++ b/tests/fx_test_app.go
@@ -215,6 +215,10 @@ func NewTestAppWithT(t testing.TB, db shared.DB, pool *pgxpool.Pool, opts *TestA
 // noopBroker is a no-op implementation of the Broker interface for testing
 type noopBroker struct{}
 
+func (n *noopBroker) IsHealthy() bool {
+	return true
+}
+
 func (n *noopBroker) Publish(ctx context.Context, message shared.PubSubMessage) error {
 	return nil
 }

--- a/tests/postgresql_broker_test.go
+++ b/tests/postgresql_broker_test.go
@@ -10,6 +10,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // testMessage for testing
@@ -222,5 +223,30 @@ func TestBrokerIntegration(t *testing.T) {
 		case <-time.After(1 * time.Second):
 			t.Error("Message not received")
 		}
+	})
+
+	t.Run("ListenerFailureMarksBrokerUnhealthy", func(t *testing.T) {
+		ctx := context.Background()
+		topic := shared.PubSubChannel("listener_health_check")
+
+		_, err := broker.Subscribe(topic)
+		require.NoError(t, err)
+		require.True(t, broker.IsHealthy())
+
+		var terminated bool
+		err = db.QueryRow(ctx, `
+			SELECT pg_terminate_backend(pid)
+			FROM pg_stat_activity
+			WHERE datname = current_database()
+				AND pid <> pg_backend_pid()
+				AND query = $1
+			LIMIT 1
+		`, `LISTEN "listener_health_check"`).Scan(&terminated)
+		require.NoError(t, err)
+		require.True(t, terminated, "listener database connection was not terminated")
+
+		require.Eventually(t, func() bool {
+			return !broker.IsHealthy()
+		}, 5*time.Second, 10*time.Millisecond)
 	})
 }


### PR DESCRIPTION
## Summary

- mark the PostgreSQL broker unhealthy when a `LISTEN` connection fails
- include broker health in `/api/v1/health/`
- verify listener failure behavior against a real PostgreSQL instance

Closes #2589

## Design decisions

### Latch listener failures

The broker's listener goroutine exits when `WaitForNotification` returns an error, and there is currently no reconnection strategy. Once that happens, the Casbin watcher can no longer receive policy change notifications.

A broker-wide atomic latch records this terminal failure. Health remains failed until the process is restarted, allowing the deployment's health-check policy to restore the listener without adding a partial reconnection mechanism.

This also avoids probing the listener connection from `IsHealthy`. The same PostgreSQL connection is already occupied by the blocking notification wait, so a concurrent ping does not reliably describe whether the listener loop is alive.

### Preserve database failure diagnostics

The health endpoint checks general database connectivity before checking the broker latch. This keeps the response specific:

- an unavailable database reports the existing database ping failure
- a reachable database with a terminated listener reports a pub/sub connection failure

### Keep recovery out of scope

The failed pooled connection is released as before. The change deliberately does not remove subscriptions or attempt to reconnect them; doing so would require preserving subscribers, re-running `LISTEN`, and defining retry behavior.

## Testing

- `go test ./database ./router ./accesscontrol`
- `go test ./tests -run '^TestBrokerIntegration$' -count=1`

The integration test establishes a real listener, terminates its PostgreSQL backend with `pg_terminate_backend`, and verifies that the broker becomes unhealthy.
