### PR TITLE
Reapply existing VEX rules after vulnerability reopening

### DIFF
--- a/controllers/vex_rule_controller.go
+++ b/controllers/vex_rule_controller.go
@@ -173,7 +173,8 @@ func (c *VEXRuleController) Get(ctx shared.Context) error {
 // @Param assetSlug path string true "Asset slug"
 // @Param assetVersionSlug path string true "Asset version slug (ref)"
 // @Param body body CreateVEXRuleRequest true "Rule data"
-// @Success 201 {object} dtos.VEXRuleDTO
+// @Success 200 {object} dtos.VEXRuleDTO "Existing rule reapplied"
+// @Success 201 {object} dtos.VEXRuleDTO "Rule created"
 // @Router /organizations/{organization}/projects/{projectSlug}/assets/{assetSlug}/refs/{assetVersionSlug}/vex-rules [post]
 func (c *VEXRuleController) Create(ctx shared.Context) error {
 	asset := shared.GetAsset(ctx)
@@ -209,32 +210,42 @@ func (c *VEXRuleController) Create(ctx shared.Context) error {
 	tx := c.vexRuleService.Begin(ctx.Request().Context())
 	defer tx.Rollback()
 
-	if err := c.vexRuleService.Create(ctx.Request().Context(), tx, rule); err != nil {
+	persistedRule, created, err := c.vexRuleService.CreateOrGet(ctx.Request().Context(), tx, rule)
+	if err != nil {
 		return echo.NewHTTPError(500, "failed to create VEX rule").WithInternal(err)
 	}
 
-	// Apply this rule to all matching existing dependency vulns
-	vulns, err := c.vexRuleService.ApplyRulesToExistingVulns(ctx.Request().Context(), tx, []models.VEXRule{*rule})
+	// Apply new rules normally. Existing rules must be forced so a historical
+	// matching event does not prevent an explicitly reopened vulnerability from closing again.
+	var vulns []models.DependencyVuln
+	if created {
+		vulns, err = c.vexRuleService.ApplyRulesToExistingVulns(ctx.Request().Context(), tx, []models.VEXRule{persistedRule})
+	} else {
+		vulns, err = c.vexRuleService.ApplyRulesToExistingVulnsForce(ctx.Request().Context(), tx, []models.VEXRule{persistedRule})
+	}
 	if err != nil {
 		slog.Error("failed to apply VEX rule to existing vulnerabilities", "error", err,
-			"cveID", rule.CVEID, "assetID", rule.AssetID, "vexSource", rule.VexSource)
-		tx.Rollback()
+			"cveID", persistedRule.CVEID, "assetID", persistedRule.AssetID, "vexSource", persistedRule.VexSource)
+		return echo.NewHTTPError(500, "failed to apply VEX rule to existing vulnerabilities").WithInternal(err)
 	}
 	if err := tx.Commit().Error; err != nil {
-		tx.Rollback()
 		return echo.NewHTTPError(500, "failed to commit VEX rule creation").WithInternal(err)
 	}
 
 	// Count matching vulnerabilities for the response
-	count, err := c.vexRuleService.CountMatchingVulns(ctx.Request().Context(), nil, *rule)
+	count, err := c.vexRuleService.CountMatchingVulns(ctx.Request().Context(), nil, persistedRule)
 	if err != nil {
-		ctx.Logger().Error("failed to count matching vulns for rule", "ruleId", rule.ID, "error", err)
+		ctx.Logger().Error("failed to count matching vulns for rule", "ruleId", persistedRule.ID, "error", err)
 		count = 0
 	}
 	// Update artifact risk aggregations in background
 	c.updateArtifactRiskAggregation(ctx.Request().Context(), asset, vulns)
 
-	return ctx.JSON(201, transformer.VEXRuleToDTOWithCount(*rule, count))
+	status := 201
+	if !created {
+		status = 200
+	}
+	return ctx.JSON(status, transformer.VEXRuleToDTOWithCount(persistedRule, count))
 }
 
 func (c *VEXRuleController) updateArtifactRiskAggregation(ctx context.Context, asset models.Asset, vulns []models.DependencyVuln) {
@@ -356,6 +367,7 @@ func (c *VEXRuleController) Update(ctx shared.Context) error {
 // @Router /organizations/{organization}/projects/{projectSlug}/assets/{assetSlug}/refs/{assetVersionSlug}/vex-rules/{ruleId}/reapply [post]
 func (c *VEXRuleController) Reapply(ctx shared.Context) error {
 	asset := shared.GetAsset(ctx)
+	assetVersion := shared.GetAssetVersion(ctx)
 
 	ruleID := ctx.Param("ruleId")
 	if ruleID == "" {
@@ -367,9 +379,9 @@ func (c *VEXRuleController) Reapply(ctx shared.Context) error {
 		return echo.NewHTTPError(404, "rule not found").WithInternal(err)
 	}
 
-	// Verify the rule belongs to this asset
-	if rule.AssetID != asset.ID {
-		return echo.NewHTTPError(403, "rule does not belong to this asset")
+	// Verify the rule belongs to this asset version
+	if rule.AssetID != asset.ID || rule.AssetVersionName != assetVersion.Name {
+		return echo.NewHTTPError(403, "rule does not belong to this asset version")
 	}
 
 	// Reapply the rule to existing vulnerabilities (force reapply ignoring duplicate checks)

--- a/controllers/vex_rule_controller.go
+++ b/controllers/vex_rule_controller.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -25,10 +26,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/dtos"
+	"github.com/l3montree-dev/devguard/services"
 	"github.com/l3montree-dev/devguard/shared"
 	"github.com/l3montree-dev/devguard/transformer"
 	"github.com/l3montree-dev/devguard/utils"
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 )
 
 type VEXRuleController struct {
@@ -212,6 +215,9 @@ func (c *VEXRuleController) Create(ctx shared.Context) error {
 
 	persistedRule, created, err := c.vexRuleService.CreateOrGet(ctx.Request().Context(), tx, rule)
 	if err != nil {
+		if errors.Is(err, services.ErrVEXRuleAssetVersionConflict) {
+			return echo.NewHTTPError(409, "matching VEX rule belongs to a different asset version").WithInternal(err)
+		}
 		return echo.NewHTTPError(500, "failed to create VEX rule").WithInternal(err)
 	}
 
@@ -376,7 +382,10 @@ func (c *VEXRuleController) Reapply(ctx shared.Context) error {
 
 	rule, err := c.vexRuleService.FindByID(ctx.Request().Context(), nil, ruleID)
 	if err != nil {
-		return echo.NewHTTPError(404, "rule not found").WithInternal(err)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(404, "rule not found").WithInternal(err)
+		}
+		return echo.NewHTTPError(500, "failed to find VEX rule").WithInternal(err)
 	}
 
 	// Verify the rule belongs to this asset version

--- a/controllers/vex_rule_controller_test.go
+++ b/controllers/vex_rule_controller_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 l3montree GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/l3montree-dev/devguard/database/models"
+	"github.com/l3montree-dev/devguard/mocks"
+	"github.com/l3montree-dev/devguard/shared"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gorm.io/gorm"
+)
+
+func TestVEXRuleControllerReapplyFindErrors(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		findError  error
+		statusCode int
+	}{
+		{
+			name:       "returns not found only for a missing rule",
+			findError:  gorm.ErrRecordNotFound,
+			statusCode: http.StatusNotFound,
+		},
+		{
+			name:       "returns internal server error for repository failures",
+			findError:  assert.AnError,
+			statusCode: http.StatusInternalServerError,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			vexRuleService := mocks.NewVEXRuleService(t)
+			vexRuleService.On("FindByID", mock.Anything, mock.Anything, "rule-id").
+				Return(models.VEXRule{}, test.findError)
+
+			e := echo.New()
+			ctx := e.NewContext(httptest.NewRequest(http.MethodPost, "/vex-rules/rule-id/reapply", nil), httptest.NewRecorder())
+			ctx.SetParamNames("ruleId")
+			ctx.SetParamValues("rule-id")
+			shared.SetAsset(ctx, models.Asset{Model: models.Model{ID: uuid.New()}})
+			shared.SetAssetVersion(ctx, models.AssetVersion{Name: "main"})
+
+			err := NewVEXRuleController(vexRuleService, nil, nil).Reapply(ctx)
+
+			var httpError *echo.HTTPError
+			if assert.ErrorAs(t, err, &httpError) {
+				assert.Equal(t, test.statusCode, httpError.Code)
+			}
+		})
+	}
+}

--- a/database/repositories/vex_rule_repository.go
+++ b/database/repositories/vex_rule_repository.go
@@ -127,6 +127,27 @@ func (r *vexRuleRepository) Create(ctx context.Context, tx *gorm.DB, rule *model
 	return r.GetDB(ctx, tx).Create(rule).Error
 }
 
+func (r *vexRuleRepository) CreateOrGet(ctx context.Context, tx *gorm.DB, rule *models.VEXRule) (models.VEXRule, bool, error) {
+	rule.EnsureID()
+
+	result := r.GetDB(ctx, tx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoNothing: true,
+	}).Create(rule)
+	if result.Error != nil {
+		return models.VEXRule{}, false, result.Error
+	}
+	if result.RowsAffected == 1 {
+		return *rule, true, nil
+	}
+
+	persistedRule, err := r.FindByID(ctx, tx, rule.ID)
+	if err != nil {
+		return models.VEXRule{}, false, err
+	}
+	return persistedRule, false, nil
+}
+
 func (r *vexRuleRepository) Upsert(ctx context.Context, tx *gorm.DB, rule *models.VEXRule) error {
 	// Ensure the ID is calculated
 	rule.EnsureID()

--- a/mocks/mock_VEXRuleRepository.go
+++ b/mocks/mock_VEXRuleRepository.go
@@ -224,6 +224,84 @@ func (_c *VEXRuleRepository_Create_Call) RunAndReturn(run func(ctx context.Conte
 	return _c
 }
 
+// CreateOrGet provides a mock function for the type VEXRuleRepository
+func (_mock *VEXRuleRepository) CreateOrGet(ctx context.Context, tx shared.DB, rule *models.VEXRule) (models.VEXRule, bool, error) {
+	ret := _mock.Called(ctx, tx, rule)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateOrGet")
+	}
+
+	if returnFunc, ok := ret.Get(0).(func(context.Context, shared.DB, *models.VEXRule) (models.VEXRule, bool, error)); ok {
+		return returnFunc(ctx, tx, rule)
+	}
+
+	var r0 models.VEXRule
+	if returnFunc, ok := ret.Get(0).(func(context.Context, shared.DB, *models.VEXRule) models.VEXRule); ok {
+		r0 = returnFunc(ctx, tx, rule)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).(models.VEXRule)
+	}
+
+	var r1 bool
+	if returnFunc, ok := ret.Get(1).(func(context.Context, shared.DB, *models.VEXRule) bool); ok {
+		r1 = returnFunc(ctx, tx, rule)
+	} else {
+		r1 = ret.Bool(1)
+	}
+
+	var r2 error
+	if returnFunc, ok := ret.Get(2).(func(context.Context, shared.DB, *models.VEXRule) error); ok {
+		r2 = returnFunc(ctx, tx, rule)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// VEXRuleRepository_CreateOrGet_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateOrGet'
+type VEXRuleRepository_CreateOrGet_Call struct {
+	*mock.Call
+}
+
+// CreateOrGet is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tx shared.DB
+//   - rule *models.VEXRule
+func (_e *VEXRuleRepository_Expecter) CreateOrGet(ctx interface{}, tx interface{}, rule interface{}) *VEXRuleRepository_CreateOrGet_Call {
+	return &VEXRuleRepository_CreateOrGet_Call{Call: _e.mock.On("CreateOrGet", ctx, tx, rule)}
+}
+
+func (_c *VEXRuleRepository_CreateOrGet_Call) Run(run func(ctx context.Context, tx shared.DB, rule *models.VEXRule)) *VEXRuleRepository_CreateOrGet_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 shared.DB
+		if args[1] != nil {
+			arg1 = args[1].(shared.DB)
+		}
+		var arg2 *models.VEXRule
+		if args[2] != nil {
+			arg2 = args[2].(*models.VEXRule)
+		}
+		run(arg0, arg1, arg2)
+	})
+	return _c
+}
+
+func (_c *VEXRuleRepository_CreateOrGet_Call) Return(rule models.VEXRule, created bool, err error) *VEXRuleRepository_CreateOrGet_Call {
+	_c.Call.Return(rule, created, err)
+	return _c
+}
+
+func (_c *VEXRuleRepository_CreateOrGet_Call) RunAndReturn(run func(ctx context.Context, tx shared.DB, rule *models.VEXRule) (models.VEXRule, bool, error)) *VEXRuleRepository_CreateOrGet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Delete provides a mock function for the type VEXRuleRepository
 func (_mock *VEXRuleRepository) Delete(ctx context.Context, tx shared.DB, rule models.VEXRule) error {
 	ret := _mock.Called(ctx, tx, rule)

--- a/mocks/mock_VEXRuleService.go
+++ b/mocks/mock_VEXRuleService.go
@@ -610,6 +610,84 @@ func (_c *VEXRuleService_Create_Call) RunAndReturn(run func(ctx context.Context,
 	return _c
 }
 
+// CreateOrGet provides a mock function for the type VEXRuleService
+func (_mock *VEXRuleService) CreateOrGet(ctx context.Context, tx shared.DB, rule *models.VEXRule) (models.VEXRule, bool, error) {
+	ret := _mock.Called(ctx, tx, rule)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateOrGet")
+	}
+
+	if returnFunc, ok := ret.Get(0).(func(context.Context, shared.DB, *models.VEXRule) (models.VEXRule, bool, error)); ok {
+		return returnFunc(ctx, tx, rule)
+	}
+
+	var r0 models.VEXRule
+	if returnFunc, ok := ret.Get(0).(func(context.Context, shared.DB, *models.VEXRule) models.VEXRule); ok {
+		r0 = returnFunc(ctx, tx, rule)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).(models.VEXRule)
+	}
+
+	var r1 bool
+	if returnFunc, ok := ret.Get(1).(func(context.Context, shared.DB, *models.VEXRule) bool); ok {
+		r1 = returnFunc(ctx, tx, rule)
+	} else {
+		r1 = ret.Bool(1)
+	}
+
+	var r2 error
+	if returnFunc, ok := ret.Get(2).(func(context.Context, shared.DB, *models.VEXRule) error); ok {
+		r2 = returnFunc(ctx, tx, rule)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// VEXRuleService_CreateOrGet_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateOrGet'
+type VEXRuleService_CreateOrGet_Call struct {
+	*mock.Call
+}
+
+// CreateOrGet is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tx shared.DB
+//   - rule *models.VEXRule
+func (_e *VEXRuleService_Expecter) CreateOrGet(ctx interface{}, tx interface{}, rule interface{}) *VEXRuleService_CreateOrGet_Call {
+	return &VEXRuleService_CreateOrGet_Call{Call: _e.mock.On("CreateOrGet", ctx, tx, rule)}
+}
+
+func (_c *VEXRuleService_CreateOrGet_Call) Run(run func(ctx context.Context, tx shared.DB, rule *models.VEXRule)) *VEXRuleService_CreateOrGet_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 shared.DB
+		if args[1] != nil {
+			arg1 = args[1].(shared.DB)
+		}
+		var arg2 *models.VEXRule
+		if args[2] != nil {
+			arg2 = args[2].(*models.VEXRule)
+		}
+		run(arg0, arg1, arg2)
+	})
+	return _c
+}
+
+func (_c *VEXRuleService_CreateOrGet_Call) Return(rule models.VEXRule, created bool, err error) *VEXRuleService_CreateOrGet_Call {
+	_c.Call.Return(rule, created, err)
+	return _c
+}
+
+func (_c *VEXRuleService_CreateOrGet_Call) RunAndReturn(run func(ctx context.Context, tx shared.DB, rule *models.VEXRule) (models.VEXRule, bool, error)) *VEXRuleService_CreateOrGet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Delete provides a mock function for the type VEXRuleService
 func (_mock *VEXRuleService) Delete(ctx context.Context, tx shared.DB, rule models.VEXRule) error {
 	ret := _mock.Called(ctx, tx, rule)

--- a/services/vex_rule_service.go
+++ b/services/vex_rule_service.go
@@ -17,6 +17,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -35,6 +36,10 @@ type VEXRuleService struct {
 }
 
 var _ shared.VEXRuleService = (*VEXRuleService)(nil)
+
+// ErrVEXRuleAssetVersionConflict indicates that a deterministic rule ID is
+// already occupied by a rule outside the requested asset-version scope.
+var ErrVEXRuleAssetVersionConflict = errors.New("vex rule conflicts with another asset version")
 
 func NewVEXRuleService(
 	vexRuleRepository shared.VEXRuleRepository,
@@ -67,7 +72,14 @@ func (s *VEXRuleService) CreateOrGet(ctx context.Context, tx shared.DB, rule *mo
 	// can resolve to a rule from another version. Enforce the full requested
 	// scope before allowing callers to apply the persisted rule.
 	if persistedRule.AssetID != rule.AssetID || persistedRule.AssetVersionName != rule.AssetVersionName {
-		return models.VEXRule{}, false, fmt.Errorf("vex rule ID resolved outside the requested asset version")
+		return models.VEXRule{}, false, fmt.Errorf(
+			"%w: persisted scope %s/%s, requested scope %s/%s",
+			ErrVEXRuleAssetVersionConflict,
+			persistedRule.AssetID,
+			persistedRule.AssetVersionName,
+			rule.AssetID,
+			rule.AssetVersionName,
+		)
 	}
 	return persistedRule, created, nil
 }

--- a/services/vex_rule_service.go
+++ b/services/vex_rule_service.go
@@ -63,6 +63,12 @@ func (s *VEXRuleService) CreateOrGet(ctx context.Context, tx shared.DB, rule *mo
 	if err != nil {
 		return models.VEXRule{}, false, fmt.Errorf("failed to create or find VEX rule: %w", err)
 	}
+	// AssetVersionName is not part of the deterministic rule ID, so a conflict
+	// can resolve to a rule from another version. Enforce the full requested
+	// scope before allowing callers to apply the persisted rule.
+	if persistedRule.AssetID != rule.AssetID || persistedRule.AssetVersionName != rule.AssetVersionName {
+		return models.VEXRule{}, false, fmt.Errorf("vex rule ID resolved outside the requested asset version")
+	}
 	return persistedRule, created, nil
 }
 

--- a/services/vex_rule_service.go
+++ b/services/vex_rule_service.go
@@ -58,6 +58,14 @@ func (s *VEXRuleService) Create(ctx context.Context, tx shared.DB, rule *models.
 	return nil
 }
 
+func (s *VEXRuleService) CreateOrGet(ctx context.Context, tx shared.DB, rule *models.VEXRule) (models.VEXRule, bool, error) {
+	persistedRule, created, err := s.vexRuleRepository.CreateOrGet(ctx, tx, rule)
+	if err != nil {
+		return models.VEXRule{}, false, fmt.Errorf("failed to create or find VEX rule: %w", err)
+	}
+	return persistedRule, created, nil
+}
+
 func (s *VEXRuleService) Begin(ctx context.Context) shared.DB {
 	return s.vexRuleRepository.Begin(ctx)
 }

--- a/services/vex_rule_service_test.go
+++ b/services/vex_rule_service_test.go
@@ -861,11 +861,14 @@ func TestVEXRuleServiceCreateOrGet(t *testing.T) {
 	requestedRule.EnsureID()
 	existingRule := *requestedRule
 	existingRule.Justification = "persisted justification"
+	otherVersionRule := existingRule
+	otherVersionRule.AssetVersionName = "release"
 
 	for _, test := range []struct {
 		name          string
 		persistedRule models.VEXRule
 		created       bool
+		wantError     bool
 	}{
 		{
 			name:          "returns newly created rule",
@@ -876,6 +879,12 @@ func TestVEXRuleServiceCreateOrGet(t *testing.T) {
 			name:          "returns existing rule without replacing its metadata",
 			persistedRule: existingRule,
 			created:       false,
+		},
+		{
+			name:          "rejects an ID conflict outside the requested asset version",
+			persistedRule: otherVersionRule,
+			created:       false,
+			wantError:     true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -889,6 +898,12 @@ func TestVEXRuleServiceCreateOrGet(t *testing.T) {
 			service := NewVEXRuleService(vexRuleRepo, depVulnRepo, vulnEventRepo)
 			persistedRule, created, err := service.CreateOrGet(context.Background(), nil, requestedRule)
 
+			if test.wantError {
+				assert.Error(t, err)
+				assert.False(t, created)
+				assert.Equal(t, models.VEXRule{}, persistedRule)
+				return
+			}
 			assert.NoError(t, err)
 			assert.Equal(t, test.created, created)
 			assert.Equal(t, test.persistedRule, persistedRule)

--- a/services/vex_rule_service_test.go
+++ b/services/vex_rule_service_test.go
@@ -848,6 +848,54 @@ func TestMatchVulnsToRules(t *testing.T) {
 	})
 }
 
+func TestVEXRuleServiceCreateOrGet(t *testing.T) {
+	assetID := uuid.New()
+	requestedRule := &models.VEXRule{
+		AssetID:          assetID,
+		AssetVersionName: "main",
+		CVEID:            "CVE-2024-1234",
+		VexSource:        "manual",
+		Justification:    "requested justification",
+		PathPattern:      []string{"pkg:golang/lib@v1.0"},
+	}
+	requestedRule.EnsureID()
+	existingRule := *requestedRule
+	existingRule.Justification = "persisted justification"
+
+	for _, test := range []struct {
+		name          string
+		persistedRule models.VEXRule
+		created       bool
+	}{
+		{
+			name:          "returns newly created rule",
+			persistedRule: *requestedRule,
+			created:       true,
+		},
+		{
+			name:          "returns existing rule without replacing its metadata",
+			persistedRule: existingRule,
+			created:       false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			vexRuleRepo := mocks.NewVEXRuleRepository(t)
+			depVulnRepo := mocks.NewDependencyVulnRepository(t)
+			vulnEventRepo := mocks.NewVulnEventRepository(t)
+
+			vexRuleRepo.On("CreateOrGet", mock.Anything, mock.Anything, requestedRule).
+				Return(test.persistedRule, test.created, nil)
+
+			service := NewVEXRuleService(vexRuleRepo, depVulnRepo, vulnEventRepo)
+			persistedRule, created, err := service.CreateOrGet(context.Background(), nil, requestedRule)
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.created, created)
+			assert.Equal(t, test.persistedRule, persistedRule)
+		})
+	}
+}
+
 // TestVEXRuleServiceCreate tests rule creation
 func TestVEXRuleServiceCreate(t *testing.T) {
 	assetID := uuid.New()

--- a/services/vex_rule_service_test.go
+++ b/services/vex_rule_service_test.go
@@ -868,7 +868,7 @@ func TestVEXRuleServiceCreateOrGet(t *testing.T) {
 		name          string
 		persistedRule models.VEXRule
 		created       bool
-		wantError     bool
+		wantError     error
 	}{
 		{
 			name:          "returns newly created rule",
@@ -884,7 +884,7 @@ func TestVEXRuleServiceCreateOrGet(t *testing.T) {
 			name:          "rejects an ID conflict outside the requested asset version",
 			persistedRule: otherVersionRule,
 			created:       false,
-			wantError:     true,
+			wantError:     ErrVEXRuleAssetVersionConflict,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -898,8 +898,8 @@ func TestVEXRuleServiceCreateOrGet(t *testing.T) {
 			service := NewVEXRuleService(vexRuleRepo, depVulnRepo, vulnEventRepo)
 			persistedRule, created, err := service.CreateOrGet(context.Background(), nil, requestedRule)
 
-			if test.wantError {
-				assert.Error(t, err)
+			if test.wantError != nil {
+				assert.ErrorIs(t, err, test.wantError)
 				assert.False(t, created)
 				assert.Equal(t, models.VEXRule{}, persistedRule)
 				return

--- a/shared/common_interfaces.go
+++ b/shared/common_interfaces.go
@@ -345,6 +345,7 @@ type VEXRuleRepository interface {
 	FindByID(ctx context.Context, tx DB, id string) (models.VEXRule, error)
 	FindByAssetAndVexSource(ctx context.Context, tx DB, assetID uuid.UUID, vexSource string) ([]models.VEXRule, error)
 	Create(ctx context.Context, tx DB, rule *models.VEXRule) error
+	CreateOrGet(ctx context.Context, tx DB, rule *models.VEXRule) (models.VEXRule, bool, error)
 	Upsert(ctx context.Context, tx DB, rule *models.VEXRule) error
 	UpsertBatch(ctx context.Context, tx DB, rules []models.VEXRule) error
 	Update(ctx context.Context, tx DB, rule *models.VEXRule) error

--- a/shared/common_interfaces.go
+++ b/shared/common_interfaces.go
@@ -503,6 +503,7 @@ type ConfigRepository interface {
 type VEXRuleService interface {
 	Begin(ctx context.Context) DB
 	Create(ctx context.Context, tx DB, rule *models.VEXRule) error
+	CreateOrGet(ctx context.Context, tx DB, rule *models.VEXRule) (models.VEXRule, bool, error)
 	Update(ctx context.Context, tx DB, rule *models.VEXRule) error
 	Delete(ctx context.Context, tx DB, rule models.VEXRule) error
 	DeleteByAssetVersion(ctx context.Context, tx DB, assetID uuid.UUID, assetVersionName string) error

--- a/tests/scan_integration_test.go
+++ b/tests/scan_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
@@ -2285,16 +2286,17 @@ func TestPathPatternVEXRules(t *testing.T) {
 			pathPattern := []string{"pkg:golang/github.com/open-policy-agent/opa@v0.68.0"}
 			ruleBody := fmt.Sprintf(`{"cveId":"CVE-2025-46569","justification":"Not exploitable in our context","mechanicalJustification":"componentNotPresent","pathPattern":["%s"]}`, pathPattern[0])
 			vexRuleController := f.App.VEXRuleController
-			postRule := func(body string) (*httptest.ResponseRecorder, error) {
+			postRule := func(body string, version models.AssetVersion) (*httptest.ResponseRecorder, error) {
 				recorder := httptest.NewRecorder()
 				req := httptest.NewRequest("POST", "/false-positive-rules", strings.NewReader(body))
 				req.Header.Set("Content-Type", "application/json")
 				ctx := app.NewContext(req, recorder)
 				setupContext(ctx)
+				shared.SetAssetVersion(ctx, version)
 				return recorder, vexRuleController.Create(ctx)
 			}
 
-			recorder, err = postRule(ruleBody)
+			recorder, err = postRule(ruleBody, assetVersion)
 			assert.Nil(t, err)
 			assert.Equal(t, 201, recorder.Code)
 
@@ -2327,7 +2329,7 @@ func TestPathPatternVEXRules(t *testing.T) {
 
 			// Creating the same rule again should reapply the persisted rule instead of failing.
 			duplicateRuleBody := strings.Replace(ruleBody, "Not exploitable in our context", "replacement justification", 1)
-			recorder, err = postRule(duplicateRuleBody)
+			recorder, err = postRule(duplicateRuleBody, assetVersion)
 			assert.Nil(t, err)
 			assert.Equal(t, 200, recorder.Code)
 
@@ -2361,13 +2363,22 @@ func TestPathPatternVEXRules(t *testing.T) {
 			}
 
 			// Retrying while the vulnerabilities are already closed remains idempotent.
-			recorder, err = postRule(ruleBody)
+			recorder, err = postRule(ruleBody, assetVersion)
 			assert.Nil(t, err)
 			assert.Equal(t, 200, recorder.Code)
 			for vulnID, eventCount := range eventCounts {
 				persistedVuln, readErr := dependencyVulnRepository.Read(context.Background(), nil, vulnID)
 				assert.Nil(t, readErr)
 				assert.Len(t, persistedVuln.Events, eventCount)
+			}
+
+			// The historical deterministic ID does not include the asset version.
+			// Surface a same-ID rule from another version as a conflict rather than a server failure.
+			otherVersion := f.CreateAssetVersion(asset.ID, "release", false)
+			_, err = postRule(ruleBody, otherVersion)
+			var httpError *echo.HTTPError
+			if assert.ErrorAs(t, err, &httpError) {
+				assert.Equal(t, http.StatusConflict, httpError.Code)
 			}
 		})
 	})

--- a/tests/scan_integration_test.go
+++ b/tests/scan_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/google/uuid"
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/dtos"
 	"github.com/l3montree-dev/devguard/mocks"
@@ -2283,14 +2284,17 @@ func TestPathPatternVEXRules(t *testing.T) {
 			// Create a VEX rule via the new dedicated endpoint
 			pathPattern := []string{"pkg:golang/github.com/open-policy-agent/opa@v0.68.0"}
 			ruleBody := fmt.Sprintf(`{"cveId":"CVE-2025-46569","justification":"Not exploitable in our context","mechanicalJustification":"componentNotPresent","pathPattern":["%s"]}`, pathPattern[0])
-			recorder = httptest.NewRecorder()
-			req = httptest.NewRequest("POST", "/false-positive-rules", strings.NewReader(ruleBody))
-			req.Header.Set("Content-Type", "application/json")
-			ctx = app.NewContext(req, recorder)
-			setupContext(ctx)
-
 			vexRuleController := f.App.VEXRuleController
-			err = vexRuleController.Create(ctx)
+			postRule := func(body string) (*httptest.ResponseRecorder, error) {
+				recorder := httptest.NewRecorder()
+				req := httptest.NewRequest("POST", "/false-positive-rules", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				ctx := app.NewContext(req, recorder)
+				setupContext(ctx)
+				return recorder, vexRuleController.Create(ctx)
+			}
+
+			recorder, err = postRule(ruleBody)
 			assert.Nil(t, err)
 			assert.Equal(t, 201, recorder.Code)
 
@@ -2305,6 +2309,66 @@ func TestPathPatternVEXRules(t *testing.T) {
 				}
 			}
 			assert.Equal(t, 2, falsePositiveCount, "both vulnerabilities should be marked as false positive by VEX rule")
+
+			// Reopen the vulnerabilities while leaving the matching VEX rule in place.
+			for i := range vulns {
+				reopenedEvent := models.NewReopenedEvent(
+					vulns[i].ID,
+					dtos.VulnTypeDependencyVuln,
+					"test-user",
+					"reopened for verification",
+					false,
+					nil,
+				)
+				err = dependencyVulnRepository.ApplyAndSave(context.Background(), nil, &vulns[i], &reopenedEvent)
+				assert.Nil(t, err)
+				assert.Equal(t, dtos.VulnStateOpen, vulns[i].State)
+			}
+
+			// Creating the same rule again should reapply the persisted rule instead of failing.
+			duplicateRuleBody := strings.Replace(ruleBody, "Not exploitable in our context", "replacement justification", 1)
+			recorder, err = postRule(duplicateRuleBody)
+			assert.Nil(t, err)
+			assert.Equal(t, 200, recorder.Code)
+
+			vulns, err = dependencyVulnRepository.GetByAssetID(context.Background(), nil, asset.ID)
+			assert.Nil(t, err)
+			eventCounts := make(map[uuid.UUID]int, len(vulns))
+			for _, vuln := range vulns {
+				assert.Equal(t, dtos.VulnStateFalsePositive, vuln.State)
+
+				persistedVuln, readErr := dependencyVulnRepository.Read(context.Background(), nil, vuln.ID)
+				assert.Nil(t, readErr)
+				falsePositiveEvents := 0
+				reopenedEvents := 0
+				for _, event := range persistedVuln.Events {
+					switch event.Type {
+					case dtos.EventTypeFalsePositive:
+						falsePositiveEvents++
+					case dtos.EventTypeReopened:
+						reopenedEvents++
+					}
+				}
+				assert.Equal(t, 2, falsePositiveEvents)
+				assert.Equal(t, 1, reopenedEvents)
+				eventCounts[vuln.ID] = len(persistedVuln.Events)
+			}
+
+			rules, err := f.App.VexRuleRepository.FindByAssetVersion(context.Background(), nil, asset.ID, assetVersion.Name)
+			assert.Nil(t, err)
+			if assert.Len(t, rules, 1, "reapplying must not create another VEX rule") {
+				assert.Equal(t, "Not exploitable in our context", rules[0].Justification, "reapplying must preserve the existing rule")
+			}
+
+			// Retrying while the vulnerabilities are already closed remains idempotent.
+			recorder, err = postRule(ruleBody)
+			assert.Nil(t, err)
+			assert.Equal(t, 200, recorder.Code)
+			for vulnID, eventCount := range eventCounts {
+				persistedVuln, readErr := dependencyVulnRepository.Read(context.Background(), nil, vulnID)
+				assert.Nil(t, readErr)
+				assert.Len(t, persistedVuln.Events, eventCount)
+			}
 		})
 	})
 }


### PR DESCRIPTION
## Summary

- make manual VEX rule creation atomically return an existing matching rule instead of failing on its deterministic ID
- force-reapply existing rules to reopened vulnerabilities while preserving the stored rule metadata
- keep VEX rule operations scoped to the requested asset version and distinguish creation (`201`) from reapplication (`200`)
- cover creation, reopening, reapplication, metadata preservation, and idempotent retries against PostgreSQL

Closes #2115

## Design decisions

### Insert or load atomically

Manual VEX rules use a deterministic primary key based on the asset, CVE, path pattern, and source. Repeating a dependency-graph selection therefore targets the same row.

The repository now uses `INSERT ... ON CONFLICT DO NOTHING` and inspects `RowsAffected`. A successful insert returns the new rule; a conflict loads the persisted rule in the same transaction. This avoids a check-then-insert race while treating the expected duplicate as valid state rather than an internal error.

### Preserve the existing rule

The conflict path deliberately does not use the existing `UpdateAll` upsert. Reapplying a rule should not replace its original justification, author, creation timestamp, enabled state, or other stored metadata with values from a repeated request.

All subsequent application, counting, logging, and response generation therefore use the persisted rule returned by the repository.

### Reapply only when the rule already exists

New rules continue through normal application and its duplicate-event protection. Existing rules use the force-reapply path so a historical VEX event does not suppress a new false-positive event after the vulnerability has explicitly been reopened.

The force path still considers only currently open vulnerabilities. Retrying the request after the vulnerability has already closed therefore creates neither another VEX rule nor another vulnerability event.

### Enforce asset-version scope in the service

`AssetVersionName` is not part of the historical deterministic rule ID. A conflict can consequently resolve to a rule stored for another version of the same asset.

`CreateOrGet` validates the persisted rule against the full requested asset/version scope before returning it. This keeps hashing details out of the controller and preserves the previous safe behavior for cross-version collisions instead of applying a rule to the wrong version. The explicit reapply endpoint also validates both route scopes because its rule ID is caller-controlled.

Changing the persisted ID format was intentionally kept out of scope: VEX rules began as asset-scoped records, and changing that identity would require a separate migration and a broader decision about cross-version rule semantics.

### Keep creation and application transactional

Rule insertion/loading and vulnerability-event application remain in one transaction. Application failures now return immediately and rely on the existing deferred rollback instead of rolling back and then continuing to a commit attempt.

The endpoint returns:

- `201 Created` when a rule is inserted
- `200 OK` when the existing rule is reapplied

The web flow already treats both as success, refreshes the vulnerability and rule data, and displays the existing success feedback, so no client-side duplicate detection is needed.

## Testing

- `go test ./...`
- `go test ./tests -run '^TestPathPatternVEXRules$' -count=1`

The integration test creates a path-based VEX rule, reopens the affected vulnerabilities, submits the same rule again with different request metadata, and verifies that:

- the vulnerabilities return to false-positive state
- the original VEX rule metadata is preserved
- only one VEX rule exists
- the event history contains the expected second false-positive event
- another retry while already closed creates no additional events
