### PR TITLE
Fix external project IDs after upsert

### DIFF
--- a/database/repositories/project_repository.go
+++ b/database/repositories/project_repository.go
@@ -509,8 +509,9 @@ func (g *projectRepository) Create(ctx context.Context, tx *gorm.DB, project *mo
 
 func (g *projectRepository) UpsertSplit(ctx context.Context, tx *gorm.DB, externalProviderID string, projects []*models.Project) ([]*models.Project, []*models.Project, error) {
 	// check which projects are already in the database - they can be identified by their external_entity_id and external_entity_provider_id
+	externalEntityIDs := utils.Map(projects, func(p *models.Project) *string { return p.ExternalEntityID })
 	var existingProjects []models.Project
-	err := g.GetDB(ctx, tx).Where("external_entity_id IN (?) AND external_entity_provider_id = ?", utils.Map(projects, func(p *models.Project) *string { return p.ExternalEntityID }), externalProviderID).Find(&existingProjects).Error
+	err := g.GetDB(ctx, tx).Where("external_entity_id IN (?) AND external_entity_provider_id = ?", externalEntityIDs, externalProviderID).Find(&existingProjects).Error
 	if err != nil {
 		return nil, nil, err
 	}
@@ -527,6 +528,21 @@ func (g *projectRepository) UpsertSplit(ctx context.Context, tx *gorm.DB, extern
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// PostgreSQL does not reliably return IDs for rows handled by the conflict-update
+	// branch. Re-read the persisted projects so callers never receive a zero UUID.
+	var persistedProjects []models.Project
+	err = g.GetDB(ctx, tx).
+		Select("id", "external_entity_id").
+		Where("external_entity_id IN (?) AND external_entity_provider_id = ?", externalEntityIDs, externalProviderID).
+		Find(&persistedProjects).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to reload upserted projects: %w", err)
+	}
+	if err := assignPersistedProjectIDs(projects, persistedProjects); err != nil {
+		return nil, nil, err
+	}
+
 	// return the splitted results
 	newProjects := make([]*models.Project, 0)
 	updatedProjects := make([]*models.Project, 0)
@@ -551,6 +567,28 @@ func (g *projectRepository) UpsertSplit(ctx context.Context, tx *gorm.DB, extern
 	}
 	// return the new and updated projects
 	return newProjects, updatedProjects, nil
+}
+
+func assignPersistedProjectIDs(projects []*models.Project, persistedProjects []models.Project) error {
+	idsByExternalEntityID := make(map[string]uuid.UUID, len(persistedProjects))
+	for _, project := range persistedProjects {
+		if project.ExternalEntityID != nil {
+			idsByExternalEntityID[*project.ExternalEntityID] = project.ID
+		}
+	}
+
+	for _, project := range projects {
+		if project.ExternalEntityID == nil {
+			return fmt.Errorf("cannot resolve database ID for project without an external entity ID")
+		}
+
+		id, ok := idsByExternalEntityID[*project.ExternalEntityID]
+		if !ok || id == uuid.Nil {
+			return fmt.Errorf("could not resolve database ID for external project %q", *project.ExternalEntityID)
+		}
+		project.ID = id
+	}
+	return nil
 }
 
 func (g *projectRepository) firstFreeSlug(ctx context.Context, tx *gorm.DB, orgID uuid.UUID, projectSlug string) (string, error) {

--- a/database/repositories/project_repository_test.go
+++ b/database/repositories/project_repository_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 l3montree GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package repositories
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/l3montree-dev/devguard/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssignPersistedProjectIDs(t *testing.T) {
+	providerID := "gitlab"
+	createdExternalID := "created"
+	updatedExternalID := "updated"
+	createdID := uuid.New()
+	updatedID := uuid.New()
+
+	projects := []*models.Project{
+		{ExternalEntityProviderID: &providerID, ExternalEntityID: &createdExternalID},
+		{ExternalEntityProviderID: &providerID, ExternalEntityID: &updatedExternalID},
+	}
+	persistedProjects := []models.Project{
+		{Model: models.Model{ID: updatedID}, ExternalEntityID: &updatedExternalID},
+		{Model: models.Model{ID: createdID}, ExternalEntityID: &createdExternalID},
+	}
+
+	err := assignPersistedProjectIDs(projects, persistedProjects)
+
+	require.NoError(t, err)
+	assert.Equal(t, createdID, projects[0].ID)
+	assert.Equal(t, updatedID, projects[1].ID)
+}
+
+func TestAssignPersistedProjectIDsRejectsMissingProject(t *testing.T) {
+	externalID := "missing"
+	projects := []*models.Project{{ExternalEntityID: &externalID}}
+
+	err := assignPersistedProjectIDs(projects, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), externalID)
+	assert.Equal(t, uuid.Nil, projects[0].ID)
+}

--- a/services/external_entity_provider_service.go
+++ b/services/external_entity_provider_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/google/uuid"
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/dtos"
 	"github.com/l3montree-dev/devguard/transformer"
@@ -300,6 +301,10 @@ func (s externalEntityProviderService) updateUserRoleInAsset(ctx context.Context
 }
 
 func (s externalEntityProviderService) syncProjectAssets(ctx shared.Context, user string, project *models.Project) ([]*models.Asset, error) {
+	if project.ID == uuid.Nil {
+		return nil, fmt.Errorf("cannot sync assets for project %q without a database ID", project.Slug)
+	}
+
 	thirdPartyIntegration := shared.GetThirdPartyIntegration(ctx)
 	domainRBAC := shared.GetRBAC(ctx)
 

--- a/services/external_entity_provider_service_test.go
+++ b/services/external_entity_provider_service_test.go
@@ -589,6 +589,22 @@ func TestSyncProjectAssets(t *testing.T) {
 		thirdPartyIntegration.AssertExpectations(t)
 	})
 
+	t.Run("project without database ID", func(t *testing.T) {
+		service := createTestService(t)
+		ctx := createTestContext()
+		project := &models.Project{
+			Slug:                     "project-without-id",
+			ExternalEntityProviderID: new("gitlab"),
+			ExternalEntityID:         new("123"),
+		}
+
+		result, err := service.syncProjectAssets(ctx, "user123", project)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "without a database ID")
+	})
+
 	t.Run("third party error", func(t *testing.T) {
 		service := createTestService(t)
 		ctx := createTestContext()

--- a/tests/project_repository_integration_test.go
+++ b/tests/project_repository_integration_test.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 l3montree GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/l3montree-dev/devguard/database/models"
+	"github.com/l3montree-dev/devguard/database/repositories"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectRepositoryUpsertSplitReturnsIDForUpdatedProject(t *testing.T) {
+	db, _, terminate := InitDatabaseContainer("../initdb.sql")
+	defer terminate()
+
+	org := models.Org{Name: "External sync test", Slug: "external-sync-test"}
+	require.NoError(t, db.Create(&org).Error)
+
+	providerID := "gitlab"
+	externalEntityID := "group-123"
+	repo := repositories.NewProjectRepository(db)
+	ctx := context.Background()
+
+	firstSyncProject := &models.Project{
+		Name:                     "Original name",
+		Slug:                     "external-project",
+		OrganizationID:           org.ID,
+		ExternalEntityProviderID: &providerID,
+		ExternalEntityID:         &externalEntityID,
+	}
+	created, updated, err := repo.UpsertSplit(ctx, nil, providerID, []*models.Project{firstSyncProject})
+	require.NoError(t, err)
+	require.Len(t, created, 1)
+	require.Empty(t, updated)
+	require.NotEqual(t, uuid.Nil, created[0].ID)
+	persistedID := created[0].ID
+
+	secondSyncProject := &models.Project{
+		Name:                     "Updated name",
+		Slug:                     "external-project",
+		OrganizationID:           org.ID,
+		ExternalEntityProviderID: &providerID,
+		ExternalEntityID:         &externalEntityID,
+	}
+	created, updated, err = repo.UpsertSplit(ctx, nil, providerID, []*models.Project{secondSyncProject})
+
+	require.NoError(t, err)
+	require.Empty(t, created)
+	require.Len(t, updated, 1)
+	assert.Equal(t, persistedID, updated[0].ID)
+	assert.NotEqual(t, uuid.Nil, updated[0].ID)
+}


### PR DESCRIPTION
## Summary

- reload externally managed projects after upsert and map their persisted database IDs back to both created and updated models
- stop asset synchronization before a zero project UUID can reach the asset upsert
- add unit and PostgreSQL integration coverage for the two-sync regression

## Testing

- `go test ./...`
- `go test ./database/repositories ./services`
- `go test ./tests -run '^TestProjectRepositoryUpsertSplitReturnsIDForUpdatedProject$' -count=1`
- `go vet ./database/repositories ./services`
- `golangci-lint run --new-from-rev=HEAD` (current container image)

Closes #2143
