### PR TITLE
Populate project slug in organization's most vulnerable assets

### DIFF
--- a/database/repositories/statistics_repository.go
+++ b/database/repositories/statistics_repository.go
@@ -303,7 +303,10 @@ func (r *statisticsRepository) GetMostVulnerableProjectsInOrg(ctx context.Contex
 func (r *statisticsRepository) GetMostVulnerableAssetsInOrg(ctx context.Context, tx *gorm.DB, orgID uuid.UUID, limit int) ([]dtos.AssetVulnDistribution, error) {
 	assets := []dtos.AssetVulnDistribution{}
 	err := r.GetDB(ctx, tx).Raw(`
-	SELECT sub.aslug, sub.aname,
+	SELECT
+		sub.project_slug,
+		sub.asset_slug,
+		sub.asset_name,
 		COUNT(*) as total,
 		COUNT(*) FILTER (WHERE sub.raw_risk_assessment < 4) AS low_risk,
 		COUNT(*) FILTER (WHERE sub.raw_risk_assessment >= 4 AND sub.raw_risk_assessment < 7) AS medium_risk,
@@ -315,7 +318,12 @@ func (r *statisticsRepository) GetMostVulnerableAssetsInOrg(ctx context.Context,
 		COUNT(*) FILTER (WHERE sub.cvss >= 9 AND sub.cvss <= 10) AS critical_cvss
 	FROM (
 		SELECT DISTINCT ON (dv.component_purl, dv.cve_id, a.id)
-			dv.raw_risk_assessment, cves.cvss, a.id as aid, a.name as aname, a.slug as aslug
+			dv.raw_risk_assessment,
+		    cves.cvss,
+		    a.id as aid,
+		    a.name as asset_name,
+			p.slug AS project_slug,
+			a.slug AS asset_slug
 		FROM dependency_vulns dv
 		JOIN cves ON cves.cve = dv.cve_id
 		JOIN assets a ON dv.asset_id = a.id
@@ -324,7 +332,7 @@ func (r *statisticsRepository) GetMostVulnerableAssetsInOrg(ctx context.Context,
 		AND dv.state = 'open'
 		ORDER BY a.id, dv.component_purl, dv.cve_id, dv.raw_risk_assessment DESC
 	) sub
-	GROUP BY sub.aid, sub.aslug,sub.aname
+	GROUP BY sub.aid, sub.project_slug, sub.asset_slug, sub.asset_name
 	ORDER BY total DESC
 	LIMIT ?;`, orgID, limit).Find(&assets).Error
 	return assets, err

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5008,6 +5008,9 @@
                     "name": {
                         "type": "string"
                     },
+                    "projectSlug": {
+                        "type": "string"
+                    },
                     "slug": {
                         "type": "string"
                     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3602,6 +3602,8 @@ components:
           type: integer
         name:
           type: string
+        projectSlug:
+          type: string
         slug:
           type: string
       type: object

--- a/dtos/statistics_dto.go
+++ b/dtos/statistics_dto.go
@@ -84,8 +84,9 @@ type ProjectVulnDistribution struct {
 }
 
 type AssetVulnDistribution struct {
-	Name string `json:"name" gorm:"column:aname"`
-	Slug string `json:"slug" gorm:"column:aslug"`
+	Name        string `json:"name"        gorm:"column:asset_name"`
+	ProjectSlug string `json:"projectSlug" gorm:"column:project_slug"`
+	Slug        string `json:"slug"        gorm:"column:asset_slug"`
 
 	VulnSeverityDistribution
 }


### PR DESCRIPTION
The web UI expects a `projectSlug` to be present for each entry of most vulnerable assets (`topAssets` within the `GET /organizations/{organization}/stats/vuln-statistics` API route) – see https://github.com/l3montree-dev/devguard-web/blob/v1.11.0/src/components/organization/MostVulnerableList.tsx#L30. However, the API implementation fails to provide this information, leading to broken links in the organization overview (within "Most Vulnerable Repositories"), e.g. `https://app.devguard.org/<org>/projects/undefined/assets/<asset>`.

This PR fixes the described problem by querying and populating the additional `projectSlug` information. The Swagger docs are slightly adjusted to reflect the updated API output.