### PR TITLE
Fixed vulnevent spam issue

### DIFF
--- a/database/models/vulnerability_model.go
+++ b/database/models/vulnerability_model.go
@@ -22,6 +22,8 @@ type Vuln interface {
 	GetScannerIDsOrArtifactNames() string
 	GetType() dtos.VulnType
 	SetTicketID(ticketID string)
+	ClearTicketID()
+	ClearTicketURL()
 	SetTicketURL(ticketURL string)
 	SetManualTicketCreation(manualTicketCreation bool)
 	GetArtifacts() []Artifact
@@ -70,9 +72,16 @@ func (d *Vulnerability) GetManualTicketCreation() bool {
 func (d *Vulnerability) SetTicketID(ticketID string) {
 	d.TicketID = &ticketID
 }
+func (d *Vulnerability) ClearTicketID() {
+	d.TicketID = nil
+}
 
 func (d *Vulnerability) SetTicketURL(ticketURL string) {
 	d.TicketURL = &ticketURL
+}
+
+func (d *Vulnerability) ClearTicketURL() {
+	d.TicketURL = nil
 }
 
 func (d *Vulnerability) SetManualTicketCreation(manualTicketCreation bool) {

--- a/integrations/githubint/github_integration.go
+++ b/integrations/githubint/github_integration.go
@@ -386,7 +386,9 @@ func (githubIntegration *GithubIntegration) HandleWebhook(ctx shared.Context) er
 
 		case "deleted":
 			vulnEvent := models.NewFalsePositiveEvent(vuln.GetID(), vuln.GetType(), fmt.Sprintf("github:%d", event.Sender.GetID()), fmt.Sprintf("This Vulnerability is marked as a false positive by %s, due to the deletion of the github ticket.", event.Sender.GetLogin()), dtos.VulnerableCodeNotInExecutePath, vuln.GetScannerIDsOrArtifactNames(), false, &userAgent)
-
+			// clear ticketID and ticketURL to mark them as deleted
+			vuln.ClearTicketID()
+			vuln.ClearTicketURL()
 			err := githubIntegration.aggregatedVulnRepository.ApplyAndSave(reqCtx, nil, vuln, &vulnEvent)
 			if err != nil {
 				slog.Error("could not save vuln and event", "err", err)
@@ -874,6 +876,9 @@ func (githubIntegration *GithubIntegration) UpdateIssue(ctx context.Context, ass
 		if err.Error() == "404 Not Found" {
 			// we can not reopen the issue - it is deleted
 			vulnEvent := models.NewFalsePositiveEvent(vuln.GetID(), vuln.GetType(), "system", "This Vulnerability is marked as a false positive due to deletion", dtos.VulnerableCodeNotInExecutePath, vuln.GetScannerIDsOrArtifactNames(), false, userAgent)
+			// clear ticketID and ticketURL to mark them as deleted
+			vuln.ClearTicketID()
+			vuln.ClearTicketURL()
 			// save the event
 			err = githubIntegration.aggregatedVulnRepository.ApplyAndSave(ctx, nil, vuln, &vulnEvent)
 			if err != nil {

--- a/integrations/githubint/github_integration_test.go
+++ b/integrations/githubint/github_integration_test.go
@@ -289,6 +289,76 @@ func TestGithubIntegrationHandleEvent(t *testing.T) {
 	})
 
 }
+
+func TestGithubIntegrationUpdateIssueUnlinksDeletedGithubIssue(t *testing.T) {
+	assetID := uuid.New()
+	orgID := uuid.New()
+	ticketID := "github:123456789/42"
+	ticketURL := "https://github.com/owner/repo/issues/42"
+	vuln := models.DependencyVuln{
+		Vulnerability: models.Vulnerability{
+			ID:               uuid.New(),
+			AssetID:          assetID,
+			AssetVersionName: "main",
+			TicketID:         &ticketID,
+			TicketURL:        &ticketURL,
+		},
+		CVE: &models.CVE{
+			CVSS:   9.8,
+			Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+		},
+		CVEID:             "CVE-2024-1234",
+		ComponentPurl:     "pkg:golang/example.com/repo@1.0.0",
+		RawRiskAssessment: new(9.8),
+	}
+
+	githubClient := mocks.NewGithubClientFacade(t)
+	githubClient.On("EditIssue", mock.Anything, "owner", "repo", 42, mock.Anything).
+		Return(nil, nil, fmt.Errorf("404 Not Found")).Once()
+
+	projectRepository := mocks.NewProjectRepository(t)
+	projectRepository.On("GetProjectByAssetID", mock.Anything, mock.Anything, assetID).
+		Return(models.Project{OrganizationID: orgID, Slug: "project"}, nil).Once()
+
+	orgRepository := mocks.NewOrganizationRepository(t)
+	orgRepository.On("Read", mock.Anything, mock.Anything, orgID).
+		Return(models.Org{Slug: "org"}, nil).Once()
+
+	vulnRepository := mocks.NewVulnRepository(t)
+	vulnRepository.On(
+		"ApplyAndSave",
+		mock.Anything,
+		mock.Anything,
+		mock.MatchedBy(func(savedVuln models.Vuln) bool {
+			return savedVuln.GetTicketID() == nil && savedVuln.GetTicketURL() == nil
+		}),
+		mock.MatchedBy(func(event *models.VulnEvent) bool {
+			return event.Type == dtos.EventTypeFalsePositive
+		}),
+	).Return(nil).Once()
+
+	integration := GithubIntegration{
+		githubClientFactory: func(repoID string) (shared.GithubClientFacade, error) {
+			return githubClient, nil
+		},
+		projectRepository:        projectRepository,
+		orgRepository:            orgRepository,
+		aggregatedVulnRepository: vulnRepository,
+		frontendURL:              "http://localhost:3000",
+	}
+
+	err := integration.UpdateIssue(context.Background(), models.Asset{
+		Model: models.Model{
+			ID: assetID,
+		},
+		Slug:         "asset",
+		RepositoryID: new("github:123:owner/repo"),
+	}, "main", &vuln, nil)
+
+	assert.NoError(t, err)
+	assert.Nil(t, vuln.GetTicketID())
+	assert.Nil(t, vuln.GetTicketURL())
+}
 func TestGithubTicketIdToIdAndNumber(t *testing.T) {
 	t.Run("it should return the correct ticket ID and number for a valid input", func(t *testing.T) {
 		id := "github:123456789/123"


### PR DESCRIPTION
Issue: https://github.com/l3montree-dev/devguard/issues/2138

The problem was that once the (false-positive) vulnevent item was created, the ticketID and ticketURL remained set for and GitHub issue that was deleted. Therefore in the next sync cycle the issue update picked up the vuln again and tried to query the ticket again. Since the ticket was deleted it returned a 404 which is also an indicator for a false-positive issue. Therefore the item got applied again. This loop keeps continuing.

Now the TicketID and TicketURL get set to `nil` on the first deletion.