### PR TITLE
Reduce unnecessary flake inputs and filter outputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1784432872,
@@ -98,27 +80,11 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
         "uv2nix": "uv2nix"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "uv2nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
 
     # uv2nix + pyproject-nix: build the scanner Python env from uv.lock,
     # replacing manual overridePythonAttrs for semgrep + checkov.
@@ -19,14 +18,37 @@
     pyproject-build-systems.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, uv2nix, pyproject-nix, pyproject-build-systems }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixpkgs-unstable,
+      uv2nix,
+      pyproject-nix,
+      pyproject-build-systems,
+    }:
+
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      eachSystem =
+        systems: f:
+        builtins.foldl' (
+          a: s: a // builtins.mapAttrs (k: v: (a.${k} or { }) // { ${s} = v; }) (f s)
+        ) { } systems;
+    in
+    eachSystem systems (
+      system:
       let
         unstablePkgs = nixpkgs-unstable.legacyPackages.${system};
         hostPkgs = nixpkgs.legacyPackages.${system} // {
           buildGoModule = unstablePkgs.buildGoModule;
         };
-     
+
         targetPkgsAmd64 = nixpkgs.legacyPackages.x86_64-linux // {
           buildGoModule = nixpkgs-unstable.legacyPackages.x86_64-linux.buildGoModule;
         };
@@ -34,9 +56,29 @@
           buildGoModule = nixpkgs-unstable.legacyPackages.aarch64-linux.buildGoModule;
         };
         # this is only done to satisfy the expected structure in the container hardening work
-        binaries = import ./nix/devguard.nix { buildGoModule = hostPkgs.buildGoModule; lib = hostPkgs.lib; inherit self system; };
-        ociImagesAmd64 = import ./nix/oci.nix { pkgs = targetPkgsAmd64; inherit self pyproject-nix uv2nix pyproject-build-systems; };
-        ociImagesArm64 = import ./nix/oci.nix { pkgs = targetPkgsArm64; inherit self pyproject-nix uv2nix pyproject-build-systems; };
+        binaries = import ./nix/devguard.nix {
+          buildGoModule = hostPkgs.buildGoModule;
+          lib = hostPkgs.lib;
+          inherit self system;
+        };
+        ociImagesAmd64 = import ./nix/oci.nix {
+          pkgs = targetPkgsAmd64;
+          inherit
+            self
+            pyproject-nix
+            uv2nix
+            pyproject-build-systems
+            ;
+        };
+        ociImagesArm64 = import ./nix/oci.nix {
+          pkgs = targetPkgsArm64;
+          inherit
+            self
+            pyproject-nix
+            uv2nix
+            pyproject-build-systems
+            ;
+        };
 
         amd64Dependencies = [
           ociImagesAmd64.craneFromSource.package
@@ -80,14 +122,13 @@
           };
         };
 
-        amd64Packages =  {
-          # those are binaries compiled for the host platform         
+        amd64Packages = {
+          # those are binaries compiled for the host platform
           devguard-amd64 = ociImagesAmd64.devguardOCI { debug = false; };
           devguard-scanner-amd64 = ociImagesAmd64.devguardScannerOCI;
           postgresql-amd64 = ociImagesAmd64.postgresqlOCI { debug = false; };
           devguard-debug-amd64 = ociImagesAmd64.devguardOCI { debug = true; };
           postgresql-debug-amd64 = ociImagesAmd64.postgresqlOCI { debug = true; };
-
 
           deps-amd64 = hostPkgs.symlinkJoin {
             name = "devguard-deps-amd64";
@@ -95,9 +136,22 @@
           };
         };
 
-      in {
-        packages = { default = commonBuildOutputs.devguard; } // arm64Packages // amd64Packages // commonBuildOutputs;
-        devShells.default =
-          hostPkgs.mkShell { buildInputs = [ unstablePkgs.go unstablePkgs.gotools unstablePkgs.gopls unstablePkgs.golangci-lint ]; };
-      });
+      in
+      {
+        packages = {
+          default = commonBuildOutputs.devguard;
+        }
+        // arm64Packages
+        // amd64Packages
+        // commonBuildOutputs;
+        devShells.default = hostPkgs.mkShell {
+          buildInputs = [
+            unstablePkgs.go
+            unstablePkgs.gotools
+            unstablePkgs.gopls
+            unstablePkgs.golangci-lint
+          ];
+        };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -40,10 +40,14 @@
         builtins.foldl' (
           a: s: a // builtins.mapAttrs (k: v: (a.${k} or { }) // { ${s} = v; }) (f s)
         ) { } systems;
+
+      inherit (nixpkgs) lib;
     in
     eachSystem systems (
       system:
       let
+        inherit (lib.systems.elaborate system) isLinux;
+
         unstablePkgs = nixpkgs-unstable.legacyPackages.${system};
         hostPkgs = nixpkgs.legacyPackages.${system} // {
           buildGoModule = unstablePkgs.buildGoModule;
@@ -92,15 +96,19 @@
           ociImagesArm64.trivyFromSource.package
         ];
 
-        commonBuildOutputs = {
+        # Built for the evaluating system, so these are the only outputs that
+        # mean anything on a non-Linux host.
+        hostBinaries = {
           devguardScanner = binaries.devguardScanner;
           devguard = binaries.devguard;
           devguardCLI = binaries.devguardCLI;
+        };
 
-          # supplementary SBOMs, exposed directly so they can be inspected
-          # (`nix build .#devguard-scanner-sbom && cat result/sboms/*.json`)
-          # without rebuilding and untarring a whole OCI image just to check
-          # one file.
+        # supplementary SBOMs, exposed directly so they can be inspected
+        # (`nix build .#devguard-scanner-sbom && cat result/sboms/*.json`)
+        # without rebuilding and untarring a whole OCI image just to check
+        # one file.
+        sbomOutputs = {
           devguard-scanner-sbom = ociImagesArm64.devguardBinaries.devguardScannerSBOM;
           devguard-sbom = ociImagesArm64.devguardBinaries.devguardSBOM;
           devguard-cli-sbom = ociImagesArm64.devguardBinaries.devguardCLISBOM;
@@ -138,12 +146,18 @@
 
       in
       {
+        # The OCI images, their SBOMs and the deps bundles are all pinned to a
+        # Linux target arch regardless of the evaluating system - the exact same
+        # derivations on every system. Exposing them under a darwin `packages`
+        # set would just be 18 attributes that need a remote builder to realise.
+        # Both Linux arches keep both target arches: `make nix-cache-push`
+        # builds deps-amd64 and deps-arm64 from a single machine, and CI splits
+        # the image builds across an amd64 and an arm64 runner.
         packages = {
-          default = commonBuildOutputs.devguard;
+          default = hostBinaries.devguard;
         }
-        // arm64Packages
-        // amd64Packages
-        // commonBuildOutputs;
+        // hostBinaries
+        // lib.optionalAttrs isLinux (sbomOutputs // arm64Packages // amd64Packages);
         devShells.default = hostPkgs.mkShell {
           buildInputs = [
             unstablePkgs.go


### PR DESCRIPTION
This PR does:

- drop `flake-utils`
  - `flake-utils` are bigger an import than the LOC that are needed to get the same effect. Unnecessarily increased the size of the lock file and evaluation closure.
  - `flake-utils` make it intransparent what target platforms are actually used
- Filter outputs so that they don't appear for platforms where they don't really make sense. Mostly darwin.
- I also used `nixfmt` to format the changes.