### PR TITLE
Added working link to markdown

### DIFF
--- a/vulndb/risk_explaination.go
+++ b/vulndb/risk_explaination.go
@@ -271,7 +271,7 @@ func (e Explanation) Markdown(baseURL, orgSlug, projectSlug, assetSlug, assetVer
 	}
 
 	str.WriteString("\n### Additional guidance for mitigating vulnerabilities\n")
-	str.WriteString("Visit our guides on [devguard.org](https://devguard.org/risk-mitigation-guides/software-composition-analysis)\n")
+	str.WriteString("Visit our guides on [devguard.org](https://docs.devguard.org/how-to-guides/scanning/scan-your-project)\n")
 
 	str.WriteString("\n<details>\n\n<summary>See more details...</summary>\n")
 	str.WriteString("\n### Path to component\n")

--- a/vulndb/risk_test.go
+++ b/vulndb/risk_test.go
@@ -518,7 +518,7 @@ func TestExplanationMarkdown(t *testing.T) {
 
 		// Test additional guidance
 		assert.Contains(t, result, "### Additional guidance for mitigating vulnerabilities")
-		assert.Contains(t, result, "[devguard.org](https://devguard.org/risk-mitigation-guides/software-composition-analysis)")
+		assert.Contains(t, result, "[devguard.org](https://docs.devguard.org/how-to-guides/scanning/scan-your-project)")
 
 		// Test details section
 		assert.Contains(t, result, "<details>")


### PR DESCRIPTION
Issue: https://github.com/l3montree-dev/devguard/issues/2689

Documenation link was removed / never existed.

Now the link is valid.