### PR TITLE
Add formatting, drop dead code

### DIFF
--- a/.github/workflows/nix-flake-check.yaml
+++ b/.github/workflows/nix-flake-check.yaml
@@ -1,0 +1,29 @@
+# Evaluates and builds all flake outputs (packages, devShells, checks)
+
+name: Nix-Flake-Check
+
+on:
+  workflow_dispatch:
+  push:
+
+permissions: {}
+
+jobs:
+  flake-check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Check out code
+      uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a # main @ 2026-07-20 (post v7.0.1)
+      with:
+        submodules: recursive
+        persist-credentials: false
+    - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+      with:
+        extra_nix_config: |
+          substituters = https://cache.nixos.org https://nix.garage.l3montree.cloud
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix.garage.l3montree.cloud:MGlzfPQKA91/zxw91CN+GP7NpjAAwmKvWXlDYgeeI8k=
+    - name: Run nix flake check
+      run: nix flake check -L

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
 
         unstablePkgs = nixpkgs-unstable.legacyPackages.${system};
         hostPkgs = nixpkgs.legacyPackages.${system} // {
-          buildGoModule = unstablePkgs.buildGoModule;
+          inherit (unstablePkgs) buildGoModule;
         };
 
         targetPkgsAmd64 = nixpkgs.legacyPackages.x86_64-linux // {
@@ -61,8 +61,10 @@
         };
         # this is only done to satisfy the expected structure in the container hardening work
         binaries = import ./nix/devguard.nix {
-          buildGoModule = hostPkgs.buildGoModule;
-          lib = hostPkgs.lib;
+          inherit (hostPkgs)
+            buildGoModule
+            lib
+            ;
           inherit self system;
         };
         ociImagesAmd64 = import ./nix/oci.nix {
@@ -99,9 +101,11 @@
         # Built for the evaluating system, so these are the only outputs that
         # mean anything on a non-Linux host.
         hostBinaries = {
-          devguardScanner = binaries.devguardScanner;
-          devguard = binaries.devguard;
-          devguardCLI = binaries.devguardCLI;
+          inherit (binaries)
+            devguardScanner
+            devguard
+            devguardCLI
+            ;
         };
 
         # supplementary SBOMs, exposed directly so they can be inspected

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
             buildGoModule
             lib
             ;
-          inherit self system;
+          inherit self;
         };
         ociImagesAmd64 = import ./nix/oci.nix {
           pkgs = targetPkgsAmd64;

--- a/flake.nix
+++ b/flake.nix
@@ -168,8 +168,35 @@
             unstablePkgs.gotools
             unstablePkgs.gopls
             unstablePkgs.golangci-lint
+            self.formatter.${system}
           ];
         };
+
+        formatter = unstablePkgs.treefmt.withConfig {
+          settings = {
+            tree-root-file = "flake.nix";
+            on-unmatched = "info";
+            formatter = {
+              nixfmt = {
+                command = lib.getExe unstablePkgs.nixfmt;
+                includes = [ "*.nix" ];
+              };
+              statix = {
+                command = lib.getExe unstablePkgs.statix;
+                options = [ "fix" ];
+                no-positional-arg-support = true;
+                includes = [ "*.nix" ];
+              };
+              deadnix = {
+                command = lib.getExe unstablePkgs.deadnix;
+                options = [ "--edit" ];
+                includes = [ "*.nix" ];
+              };
+            };
+          };
+        };
+
+        checks.formatting = self.formatter.${system}.check self;
       }
     );
 }

--- a/nix/common.nix
+++ b/nix/common.nix
@@ -9,9 +9,12 @@ let
       githubRef = builtins.getEnv "GITHUB_REF_NAME";
       gitlabRef = builtins.getEnv "CI_COMMIT_REF_NAME";
     in
-    if githubRef != "" then githubRef
-    else if gitlabRef != "" then gitlabRef
-    else "";
+    if githubRef != "" then
+      githubRef
+    else if gitlabRef != "" then
+      gitlabRef
+    else
+      "";
 in
 rec {
   version = if refName != "" then refName else self.shortRev or self.dirtyShortRev or "dev";

--- a/nix/crane.nix
+++ b/nix/crane.nix
@@ -1,6 +1,14 @@
 # Upstream nixpkgs definition:
 # https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/by-name/go/go-containerregistry/package.nix
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, runCommand, jq, trivy }:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  runCommand,
+  jq,
+  trivy,
+}:
 
 let
   pname = "crane";
@@ -35,7 +43,9 @@ let
       "-X github.com/google/go-containerregistry/cmd/crane/cmd.Version=v${version}"
       "-X github.com/google/go-containerregistry/internal/version.Version=${version}"
     ];
-    env = { CGO_ENABLED = 0; };
+    env = {
+      CGO_ENABLED = 0;
+    };
     nativeBuildInputs = [ installShellFiles ];
 
     postInstall = "";
@@ -59,6 +69,11 @@ in
     toolName = "crane";
     inherit src version modulePurl;
     inherit (package) goModules;
-    binaries = [{ name = "crane"; binPath = "${package}/bin/crane"; }];
+    binaries = [
+      {
+        name = "crane";
+        binPath = "${package}/bin/crane";
+      }
+    ];
   };
 }

--- a/nix/crane.nix
+++ b/nix/crane.nix
@@ -58,7 +58,7 @@ in
   sbom = mkToolSBOM {
     toolName = "crane";
     inherit src version modulePurl;
-    goModules = package.goModules;
+    inherit (package) goModules;
     binaries = [{ name = "crane"; binPath = "${package}/bin/crane"; }];
   };
 }

--- a/nix/devguard.nix
+++ b/nix/devguard.nix
@@ -1,5 +1,5 @@
 {
-  buildGoModule, lib, self, system,
+  buildGoModule, lib, self,
   # optional: only needed to build devguardScannerSBOM (passed explicitly
   # from oci.nix). The plain "binaries" call site in flake.nix never
   # references that attribute, so it's fine for these to stay null there.

--- a/nix/devguard.nix
+++ b/nix/devguard.nix
@@ -1,10 +1,15 @@
 {
-  buildGoModule, lib, self,
+  buildGoModule,
+  lib,
+  self,
   # optional: only needed to build devguardScannerSBOM (passed explicitly
   # from oci.nix). The plain "binaries" call site in flake.nix never
   # references that attribute, so it's fine for these to stay null there.
-  runCommand ? null, jq ? null, trivy ? null,
-}: rec {
+  runCommand ? null,
+  jq ? null,
+  trivy ? null,
+}:
+rec {
   common = import ./common.nix { inherit self lib; };
   ldflags = [
     "-s"
@@ -47,31 +52,39 @@
     proxyVendor = true;
     vendorHash = "sha256-AkMVxG6Lp+6Nd8mpPbOEi86H3PxGgE6WgM69QJF+uaM=";
     inherit ldflags;
-    buildFlags =
-      [ "-trimpath" ]; # compiler-level flag, mirrors Makefile FLAGS
+    buildFlags = [ "-trimpath" ]; # compiler-level flag, mirrors Makefile FLAGS
     doCheck = false;
     env = {
       CGO_ENABLED = 0; # static binary, no cgo
     };
   };
 
-  devguardScanner = buildGoModule (commonArgs // {
-    pname = "devguard-scanner";
-    inherit (common) version;
-    subPackages = [ "cmd/devguard-scanner" ];
-  });
+  devguardScanner = buildGoModule (
+    commonArgs
+    // {
+      pname = "devguard-scanner";
+      inherit (common) version;
+      subPackages = [ "cmd/devguard-scanner" ];
+    }
+  );
 
-  devguard = buildGoModule (commonArgs // {
-    pname = "devguard";
-    inherit (common) version;
-    subPackages = [ "cmd/devguard" ];
-  });
+  devguard = buildGoModule (
+    commonArgs
+    // {
+      pname = "devguard";
+      inherit (common) version;
+      subPackages = [ "cmd/devguard" ];
+    }
+  );
 
-  devguardCLI = buildGoModule (commonArgs // {
-    pname = "devguard-cli";
-    inherit (common) version;
-    subPackages = [ "cmd/devguard-cli" ];
-  });
+  devguardCLI = buildGoModule (
+    commonArgs
+    // {
+      pname = "devguard-cli";
+      inherit (common) version;
+      subPackages = [ "cmd/devguard-cli" ];
+    }
+  );
 
   # devguard-scanner ends up scanning devguard's own images, and trivy
   # detects each of these compiled binaries the same way it detects
@@ -93,7 +106,12 @@
     inherit (common) version;
     modulePurl = "pkg:golang/github.com/l3montree-dev/devguard";
     inherit (devguardScanner) goModules;
-    binaries = [{ name = "devguard-scanner"; binPath = "${devguardScanner}/bin/devguard-scanner"; }];
+    binaries = [
+      {
+        name = "devguard-scanner";
+        binPath = "${devguardScanner}/bin/devguard-scanner";
+      }
+    ];
     externalReferences = [
       {
         type = "exploitability-statement";
@@ -109,7 +127,10 @@
     modulePurl = "pkg:golang/github.com/l3montree-dev/devguard";
     inherit (devguard) goModules;
     binaries = [
-      { name = "devguard"; binPath = "${devguard}/bin/devguard"; }
+      {
+        name = "devguard";
+        binPath = "${devguard}/bin/devguard";
+      }
     ];
   };
 
@@ -119,6 +140,11 @@
     inherit (common) version;
     modulePurl = "pkg:golang/github.com/l3montree-dev/devguard";
     inherit (devguardCLI) goModules;
-    binaries = [{ name = "devguard-cli"; binPath = "${devguardCLI}/bin/devguard-cli"; }];
+    binaries = [
+      {
+        name = "devguard-cli";
+        binPath = "${devguardCLI}/bin/devguard-cli";
+      }
+    ];
   };
 }

--- a/nix/devguard.nix
+++ b/nix/devguard.nix
@@ -57,19 +57,19 @@
 
   devguardScanner = buildGoModule (commonArgs // {
     pname = "devguard-scanner";
-    version = common.version;
+    inherit (common) version;
     subPackages = [ "cmd/devguard-scanner" ];
   });
 
   devguard = buildGoModule (commonArgs // {
     pname = "devguard";
-    version = common.version;
+    inherit (common) version;
     subPackages = [ "cmd/devguard" ];
   });
 
   devguardCLI = buildGoModule (commonArgs // {
     pname = "devguard-cli";
-    version = common.version;
+    inherit (common) version;
     subPackages = [ "cmd/devguard-cli" ];
   });
 
@@ -90,9 +90,9 @@
   devguardScannerSBOM = mkToolSBOM {
     toolName = "devguard-scanner";
     inherit src;
-    version = common.version;
+    inherit (common) version;
     modulePurl = "pkg:golang/github.com/l3montree-dev/devguard";
-    goModules = devguardScanner.goModules;
+    inherit (devguardScanner) goModules;
     binaries = [{ name = "devguard-scanner"; binPath = "${devguardScanner}/bin/devguard-scanner"; }];
     externalReferences = [
       {
@@ -105,9 +105,9 @@
   devguardSBOM = mkToolSBOM {
     toolName = "devguard-api";
     inherit src;
-    version = common.version;
+    inherit (common) version;
     modulePurl = "pkg:golang/github.com/l3montree-dev/devguard";
-    goModules = devguard.goModules;
+    inherit (devguard) goModules;
     binaries = [
       { name = "devguard"; binPath = "${devguard}/bin/devguard"; }
     ];
@@ -116,9 +116,9 @@
   devguardCLISBOM = mkToolSBOM {
     toolName = "devguard-cli";
     inherit src;
-    version = common.version;
+    inherit (common) version;
     modulePurl = "pkg:golang/github.com/l3montree-dev/devguard";
-    goModules = devguardCLI.goModules;
+    inherit (devguardCLI) goModules;
     binaries = [{ name = "devguard-cli"; binPath = "${devguardCLI}/bin/devguard-cli"; }];
   };
 }

--- a/nix/gitleaks.nix
+++ b/nix/gitleaks.nix
@@ -52,7 +52,7 @@ in
   sbom = mkToolSBOM {
     toolName = "gitleaks";
     inherit src version modulePurl;
-    goModules = package.goModules;
+    inherit (package) goModules;
     binaries = [{ name = "gitleaks"; binPath = "${package}/bin/gitleaks"; }];
   };
 }

--- a/nix/gitleaks.nix
+++ b/nix/gitleaks.nix
@@ -1,6 +1,14 @@
 # Upstream nixpkgs definition:
 # https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/by-name/gi/gitleaks/package.nix
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, runCommand, jq, trivy }:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  runCommand,
+  jq,
+  trivy,
+}:
 
 let
   pname = "gitleaks";
@@ -53,6 +61,11 @@ in
     toolName = "gitleaks";
     inherit src version modulePurl;
     inherit (package) goModules;
-    binaries = [{ name = "gitleaks"; binPath = "${package}/bin/gitleaks"; }];
+    binaries = [
+      {
+        name = "gitleaks";
+        binPath = "${package}/bin/gitleaks";
+      }
+    ];
   };
 }

--- a/nix/oci.nix
+++ b/nix/oci.nix
@@ -1,6 +1,5 @@
 { pkgs, self, pyproject-nix, uv2nix, pyproject-build-systems }: rec {
   devguardBinaries = import ./devguard.nix {
-    system = pkgs.stdenv.hostPlatform.system;
     inherit self;
     inherit (pkgs)
       buildGoModule

--- a/nix/oci.nix
+++ b/nix/oci.nix
@@ -1,21 +1,25 @@
 { pkgs, self, pyproject-nix, uv2nix, pyproject-build-systems }: rec {
   devguardBinaries = import ./devguard.nix {
-    inherit self;
-    buildGoModule = pkgs.buildGoModule;
-    lib = pkgs.lib;
     system = pkgs.stdenv.hostPlatform.system;
-    runCommand = pkgs.runCommand;
-    jq = pkgs.jq;
+    inherit self;
+    inherit (pkgs)
+      buildGoModule
+      lib
+      runCommand
+      jq
+      ;
     trivy = trivyFromSource.package;
   };
 
   args = {
-    lib = pkgs.lib;
-    buildGoModule = pkgs.buildGoModule;
-    fetchFromGitHub = pkgs.fetchFromGitHub;
-    installShellFiles = pkgs.installShellFiles;
-    runCommand = pkgs.runCommand;
-    jq = pkgs.jq;
+    inherit (pkgs)
+      lib
+      buildGoModule
+      fetchFromGitHub
+      installShellFiles
+      runCommand
+      jq
+      ;
   };
 
   # trivy is self-contained (scans its own source with its own freshly-built
@@ -24,24 +28,28 @@
   craneFromSource = import ./crane.nix (args // { trivy = trivyFromSource.package; });
   gitleaksFromSource = import ./gitleaks.nix (args // { trivy = trivyFromSource.package; });
 
-  common = import ./common.nix { inherit self; lib = pkgs.lib; };
+  common = import ./common.nix { inherit self; inherit (pkgs) lib; };
   # Docker tags can't contain "/", so a branch like "feature/foo" -> "feature-foo".
   dockerTag = builtins.replaceStrings [ "/" ] [ "-" ] common.version;
   postgresql = import ./postgresql.nix {
-    postgresql_16 = pkgs.postgresql_16;
-    fetchurl = pkgs.fetchurl;
-    stdenv = pkgs.stdenv;
-    runCommand = pkgs.runCommand;
+    inherit (pkgs)
+      postgresql_16
+      fetchurl
+      stdenv
+      runCommand
+      ;
   };
   pythonTools = import ./python-tools.nix {
-  lib = pkgs.lib;
-  python313 = pkgs.python313;
-  callPackage = pkgs.callPackage;
-  runCommand = pkgs.runCommand;
-  jq = pkgs.jq;
-  trivy = trivyFromSource.package;
-  # passed explicitly from flake.nix
-  inherit uv2nix pyproject-nix pyproject-build-systems;
+    inherit (pkgs)
+      lib
+      python313
+      callPackage
+      runCommand
+      jq
+      ;
+    trivy = trivyFromSource.package;
+    # passed explicitly from flake.nix
+    inherit uv2nix pyproject-nix pyproject-build-systems;
   };
 
   # Unlike the Go tools above (see gitleaks.nix/trivy.nix/crane.nix, which each

--- a/nix/oci.nix
+++ b/nix/oci.nix
@@ -1,4 +1,11 @@
-{ pkgs, self, pyproject-nix, uv2nix, pyproject-build-systems }: rec {
+{
+  pkgs,
+  self,
+  pyproject-nix,
+  uv2nix,
+  pyproject-build-systems,
+}:
+rec {
   devguardBinaries = import ./devguard.nix {
     inherit self;
     inherit (pkgs)
@@ -27,7 +34,10 @@
   craneFromSource = import ./crane.nix (args // { trivy = trivyFromSource.package; });
   gitleaksFromSource = import ./gitleaks.nix (args // { trivy = trivyFromSource.package; });
 
-  common = import ./common.nix { inherit self; inherit (pkgs) lib; };
+  common = import ./common.nix {
+    inherit self;
+    inherit (pkgs) lib;
+  };
   # Docker tags can't contain "/", so a branch like "feature/foo" -> "feature-foo".
   dockerTag = builtins.replaceStrings [ "/" ] [ "-" ] common.version;
   postgresql = import ./postgresql.nix {
@@ -62,61 +72,60 @@
   # no embedded compiled binary, so trivy already resolves it (and its
   # dependencies) as ordinary pypi library components.
   semgrepSBOM = pkgs.runCommand "semgrep-sbom" { } ''
-    mkdir -p $out/sboms
-    binPath="${pythonTools.pythonSet.semgrep}/lib/python3.13/site-packages/semgrep/bin/semgrep-core"
-    name="''${binPath#/}"
-    cat > $out/sboms/semgrep-core.json <<EOF
-{
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
-  "metadata": {
-    "component": {
-      "type": "application",
-      "bom-ref": "$name",
-      "name": "$name",
-      "version": "${pythonTools.pythonSet.semgrep.version}"
+        mkdir -p $out/sboms
+        binPath="${pythonTools.pythonSet.semgrep}/lib/python3.13/site-packages/semgrep/bin/semgrep-core"
+        name="''${binPath#/}"
+        cat > $out/sboms/semgrep-core.json <<EOF
+    {
+      "bomFormat": "CycloneDX",
+      "specVersion": "1.5",
+      "metadata": {
+        "component": {
+          "type": "application",
+          "bom-ref": "$name",
+          "name": "$name",
+          "version": "${pythonTools.pythonSet.semgrep.version}"
+        }
+      }
     }
-  }
-}
-EOF
+    EOF
   '';
 
   appConfig = pkgs.runCommand "devguard-app-config" { } ''
-    install -D -m 0644 ${
-      ../config/rbac_model.conf
-    } $out/app/config/rbac_model.conf
-    install -D -m 0644 ${
-      ../intoto-public-key.pem
-    }  $out/app/intoto-public-key.pem
+    install -D -m 0644 ${../config/rbac_model.conf} $out/app/config/rbac_model.conf
+    install -D -m 0644 ${../intoto-public-key.pem}  $out/app/intoto-public-key.pem
     install -D -m 0644 ${../cosign.pub} $out/app/cosign.pub
   '';
 
-  devguardOCI = { debug }: pkgs.dockerTools.buildLayeredImage {
-    name = "devguard";
-    tag = dockerTag;
+  devguardOCI =
+    { debug }:
+    pkgs.dockerTools.buildLayeredImage {
+      name = "devguard";
+      tag = dockerTag;
 
-    contents = [
-      pkgs.cacert  # TLS root certificates (needed for outbound HTTPS)
-      devguardBinaries.devguard
-      devguardBinaries.devguardCLI
-      devguardBinaries.devguardSBOM
-      devguardBinaries.devguardCLISBOM
-      appConfig
-    ] ++ (if debug then [ pkgs.busybox ] else []);
+      contents = [
+        pkgs.cacert # TLS root certificates (needed for outbound HTTPS)
+        devguardBinaries.devguard
+        devguardBinaries.devguardCLI
+        devguardBinaries.devguardSBOM
+        devguardBinaries.devguardCLISBOM
+        appConfig
+      ]
+      ++ (if debug then [ pkgs.busybox ] else [ ]);
 
-    config = {
-      Cmd = [ "/bin/devguard" ];
-      WorkingDir = "/app";
-      User = "53111:53111";
-      Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
+      config = {
+        Cmd = [ "/bin/devguard" ];
+        WorkingDir = "/app";
+        User = "53111:53111";
+        Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
+      };
     };
-  };
 
   devguardScannerOCI = pkgs.dockerTools.buildLayeredImage {
     name = "devguard-scanner";
     tag = dockerTag;
-    contents =  [
-      pkgs.cacert  # TLS root certificates (needed for outbound HTTPS)
+    contents = [
+      pkgs.cacert # TLS root certificates (needed for outbound HTTPS)
       devguardBinaries.devguardScanner
       trivyFromSource.package
       pythonTools.venv
@@ -145,52 +154,68 @@ EOF
     config = {
       Cmd = [ "/bin/devguard-scanner" ];
       User = "53111:53111";
-      Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" "EIO_BACKEND=posix" "HOME=/tmp" "TRIVY_CACHE_DIR=/tmp/.cache/trivy" "SEMGREP_CACHE_DIR=/tmp/.cache/semgrep" "DOCKER_CONFIG=/tmp/.docker" ];
-    };
-  };
-
-  postgresqlOCI = { debug }: pkgs.dockerTools.buildLayeredImage {
-    name = "devguard-postgresql";
-    tag = "16";
-
-    contents = [
-      pkgs.cacert
-      pkgs.glibcLocales  # en_US.UTF-8 locale support
-      postgresql.psql
-      postgresql.entrypoint
-      postgresql.config
-      pkgs.bash
-      pkgs.coreutils
-    ] ++ (if debug then [ pkgs.busybox ] else []);
-
-    # Create the postgres user (uid/gid 999, matching the official image),
-    # the data directory, and the unix socket directory.
-    fakeRootCommands = ''
-      mkdir -p etc
-      echo 'postgres:x:999:999:PostgreSQL Server:/var/lib/postgresql:/bin/bash' \
-        >> etc/passwd
-      echo 'postgres:x:999:' >> etc/group
-      mkdir -p var/lib/postgresql/data
-      mkdir -p var/run/postgresql
-      chown -R 999:999 var/lib/postgresql var/run/postgresql
-      # Ensure this path exists in all CI environments for stable layer output.
-      mkdir -p nix/var/nix/builds
-    '';
-    enableFakechroot = true;
-
-    config = {
-      Entrypoint = [ "/bin/docker-entrypoint.sh" ];
-      Cmd = [ "postgres" "-c" "config_file=/etc/postgresql/postgresql.conf" ];
-      User = "999:999";
       Env = [
-        "LANG=en_US.UTF-8"
-        "LC_ALL=en_US.UTF-8"
-        "PGDATA=/var/lib/postgresql/data"
         "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-        # Tell glibc where the locale archive is inside the Nix store.
-        "LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive"
+        "EIO_BACKEND=posix"
+        "HOME=/tmp"
+        "TRIVY_CACHE_DIR=/tmp/.cache/trivy"
+        "SEMGREP_CACHE_DIR=/tmp/.cache/semgrep"
+        "DOCKER_CONFIG=/tmp/.docker"
       ];
-      Volumes = { "/var/lib/postgresql/data" = {}; };
     };
   };
+
+  postgresqlOCI =
+    { debug }:
+    pkgs.dockerTools.buildLayeredImage {
+      name = "devguard-postgresql";
+      tag = "16";
+
+      contents = [
+        pkgs.cacert
+        pkgs.glibcLocales # en_US.UTF-8 locale support
+        postgresql.psql
+        postgresql.entrypoint
+        postgresql.config
+        pkgs.bash
+        pkgs.coreutils
+      ]
+      ++ (if debug then [ pkgs.busybox ] else [ ]);
+
+      # Create the postgres user (uid/gid 999, matching the official image),
+      # the data directory, and the unix socket directory.
+      fakeRootCommands = ''
+        mkdir -p etc
+        echo 'postgres:x:999:999:PostgreSQL Server:/var/lib/postgresql:/bin/bash' \
+          >> etc/passwd
+        echo 'postgres:x:999:' >> etc/group
+        mkdir -p var/lib/postgresql/data
+        mkdir -p var/run/postgresql
+        chown -R 999:999 var/lib/postgresql var/run/postgresql
+        # Ensure this path exists in all CI environments for stable layer output.
+        mkdir -p nix/var/nix/builds
+      '';
+      enableFakechroot = true;
+
+      config = {
+        Entrypoint = [ "/bin/docker-entrypoint.sh" ];
+        Cmd = [
+          "postgres"
+          "-c"
+          "config_file=/etc/postgresql/postgresql.conf"
+        ];
+        User = "999:999";
+        Env = [
+          "LANG=en_US.UTF-8"
+          "LC_ALL=en_US.UTF-8"
+          "PGDATA=/var/lib/postgresql/data"
+          "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+          # Tell glibc where the locale archive is inside the Nix store.
+          "LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive"
+        ];
+        Volumes = {
+          "/var/lib/postgresql/data" = { };
+        };
+      };
+    };
 }

--- a/nix/postgresql.nix
+++ b/nix/postgresql.nix
@@ -3,7 +3,13 @@
 # Upstream nixpkgs definitions:
 #   https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/servers/sql/postgresql/default.nix
 #   https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/servers/sql/postgresql/ext/pg-semver.nix
-{ postgresql_16, fetchurl, stdenv, runCommand }: rec {
+{
+  postgresql_16,
+  fetchurl,
+  stdenv,
+  runCommand,
+}:
+rec {
   psql = postgresql_16.withPackages (p: [ p.pg-semver ]);
 
   entrypoint = stdenv.mkDerivation {
@@ -18,7 +24,7 @@
     '';
   };
 
-  config = runCommand "postgresql-config" {} ''
+  config = runCommand "postgresql-config" { } ''
     install -D -m 0644 ${./postgresql.conf} $out/etc/postgresql/postgresql.conf
   '';
 }

--- a/nix/python-tools.nix
+++ b/nix/python-tools.nix
@@ -21,7 +21,8 @@
   pyproject-build-systems,
   # passed explicitly from oci.nix (its own package, built from trivy.nix)
   trivy,
-}: rec {
+}:
+rec {
   workspace = uv2nix.lib.workspace.loadWorkspace {
     workspaceRoot = ./python-tools;
   };
@@ -32,12 +33,16 @@
     sourcePreference = "wheel";
   };
 
-  pythonSet = (callPackage pyproject-nix.build.packages {
-    python = python313;
-  }).overrideScope (lib.composeManyExtensions [
-    pyproject-build-systems.overlays.wheel
-    overlay
-  ]);
+  pythonSet =
+    (callPackage pyproject-nix.build.packages {
+      python = python313;
+    }).overrideScope
+      (
+        lib.composeManyExtensions [
+          pyproject-build-systems.overlays.wheel
+          overlay
+        ]
+      );
   venv = pythonSet.mkVirtualEnv "devguard-scanner-tools" workspace.deps.default;
 
   # Trivy's *image* scan of the venv (installed site-packages) can only see a
@@ -74,29 +79,34 @@
   # (which considers every bundled component, not just direct children)
   # demotes each one's flat direct-root edge in this single merge, no matter
   # how deep it sits in the real tree.
-  sbom = runCommand "python-tools-sbom" {
-    nativeBuildInputs = [ trivy jq ];
-  } ''
-    mkdir -p $out/sboms
+  sbom =
+    runCommand "python-tools-sbom"
+      {
+        nativeBuildInputs = [
+          trivy
+          jq
+        ];
+      }
+      ''
+        mkdir -p $out/sboms
 
-    export HOME="$TMPDIR"
-    export TRIVY_CACHE_DIR="$TMPDIR/.trivy-cache"
+        export HOME="$TMPDIR"
+        export TRIVY_CACHE_DIR="$TMPDIR/.trivy-cache"
 
-    cp -r ${./python-tools} ./src
-    chmod -R u+w ./src
+        cp -r ${./python-tools} ./src
+        chmod -R u+w ./src
 
-    trivy fs --offline-scan --format cyclonedx --output raw.json ./src
+        trivy fs --offline-scan --format cyclonedx --output raw.json ./src
 
-    jq '
-      ([.components[]?."bom-ref"]) as $valid
-      | .components = [.components[] | select(."bom-ref" as $r | $valid | index($r))]
-      | .dependencies = [
-          .dependencies[]?
-          | select(.ref as $r | $valid | index($r))
-          | .dependsOn = [(.dependsOn // [])[] | select(. as $d | $valid | index($d))]
-        ]
-      | .metadata.component = (.components[] | select(.name == "devguard-scanner-tools"))
-    ' raw.json > "$out/sboms/devguard-scanner-tools.json"
-  '';
+        jq '
+          ([.components[]?."bom-ref"]) as $valid
+          | .components = [.components[] | select(."bom-ref" as $r | $valid | index($r))]
+          | .dependencies = [
+              .dependencies[]?
+              | select(.ref as $r | $valid | index($r))
+              | .dependsOn = [(.dependsOn // [])[] | select(. as $d | $valid | index($d))]
+            ]
+          | .metadata.component = (.components[] | select(.name == "devguard-scanner-tools"))
+        ' raw.json > "$out/sboms/devguard-scanner-tools.json"
+      '';
 }
-

--- a/nix/sbom-lib.nix
+++ b/nix/sbom-lib.nix
@@ -33,80 +33,102 @@
 # components by exact Name, so this gives it two independent, correctly
 # identified nodes to fix: the path-keyed application stub, and the
 # versionless module/library duplicate.
-{ lib, runCommand, jq }:
+{
+  lib,
+  runCommand,
+  jq,
+}:
 
 { trivy }:
 
-{ toolName, src, version, modulePurl, binaries, externalReferences ? [ ], goModules ? null }:
+{
+  toolName,
+  src,
+  version,
+  modulePurl,
+  binaries,
+  externalReferences ? [ ],
+  goModules ? null,
+}:
 let
   versionedModule = "${modulePurl}@${version}";
   externalReferencesJson = builtins.toJSON externalReferences;
 in
-runCommand "${toolName}-sbom" {
-  nativeBuildInputs = [ trivy jq ];
-} ''
-  mkdir -p $out/sboms
+runCommand "${toolName}-sbom"
+  {
+    nativeBuildInputs = [
+      trivy
+      jq
+    ];
+  }
+  ''
+    mkdir -p $out/sboms
 
-  export HOME="$TMPDIR"
-  export TRIVY_CACHE_DIR="$TMPDIR/.trivy-cache"
+    export HOME="$TMPDIR"
+    export TRIVY_CACHE_DIR="$TMPDIR/.trivy-cache"
 
-  cp -r ${src} ./src
-  chmod -R u+w ./src
+    cp -r ${src} ./src
+    chmod -R u+w ./src
 
-  ${lib.optionalString (goModules != null) ''
-    # For a real transitive tree, trivy reads each dependency's go.mod from the
-    # EXTRACTED module layout ($GOPATH/pkg/mod/<escaped-module>@<version>/go.mod;
-    # it reads GOPATH, never GOMODCACHE, and never runs `go`). goModules only
-    # ships the DOWNLOAD cache (.../cache/download/<module>/@v/<version>.mod),
-    # which trivy ignores - so without this, no dep go.mod is found, no edges
-    # are built, and every module is dumped flat under the main module.
-    # Both layouts share the same escaping, so materialize the extracted go.mod
-    # tree from the download cache with a plain copy - no `go`, no network.
-    export GOPATH="$TMPDIR/go"
-    modcache="$GOPATH/pkg/mod"
-    mkdir -p "$modcache/cache"
-    cp -r --no-preserve=mode,ownership ${goModules} "$modcache/cache/download"
-    chmod -R u+w "$modcache/cache/download"
+    ${lib.optionalString (goModules != null) ''
+      # For a real transitive tree, trivy reads each dependency's go.mod from the
+      # EXTRACTED module layout ($GOPATH/pkg/mod/<escaped-module>@<version>/go.mod;
+      # it reads GOPATH, never GOMODCACHE, and never runs `go`). goModules only
+      # ships the DOWNLOAD cache (.../cache/download/<module>/@v/<version>.mod),
+      # which trivy ignores - so without this, no dep go.mod is found, no edges
+      # are built, and every module is dumped flat under the main module.
+      # Both layouts share the same escaping, so materialize the extracted go.mod
+      # tree from the download cache with a plain copy - no `go`, no network.
+      export GOPATH="$TMPDIR/go"
+      modcache="$GOPATH/pkg/mod"
+      mkdir -p "$modcache/cache"
+      cp -r --no-preserve=mode,ownership ${goModules} "$modcache/cache/download"
+      chmod -R u+w "$modcache/cache/download"
 
-    prefix="$modcache/cache/download/"
-    find "$modcache/cache/download" -type f -name '*.mod' | while read -r modfile; do
-      rel="''${modfile#$prefix}"   # <escaped-module>/@v/<version>.mod
-      mod="''${rel%%/@v/*}"        # <escaped-module>
-      ver="$(basename "$modfile" .mod)"  # <version>
-      dest="$modcache/$mod@$ver"
-      mkdir -p "$dest"
-      cp "$modfile" "$dest/go.mod"
-    done
-  ''}
+      prefix="$modcache/cache/download/"
+      find "$modcache/cache/download" -type f -name '*.mod' | while read -r modfile; do
+        rel="''${modfile#$prefix}"   # <escaped-module>/@v/<version>.mod
+        mod="''${rel%%/@v/*}"        # <escaped-module>
+        ver="$(basename "$modfile" .mod)"  # <version>
+        dest="$modcache/$mod@$ver"
+        mkdir -p "$dest"
+        cp "$modfile" "$dest/go.mod"
+      done
+    ''}
 
-  trivy fs --offline-scan --format cyclonedx --output raw.json ./src
+    trivy fs --offline-scan --format cyclonedx --output raw.json ./src
 
-  # A source tree full of its own embedded test fixtures (e.g. trivy's own
-  # repo, full of testdata go.mod/package.json/etc fixtures for its own
-  # analyzer tests) makes trivy's fs scan produce a mess of synthetic
-  # intermediate grouping nodes - referenced from .dependencies but with no
-  # matching entry in .components at all. Left in, these become dangling refs
-  # our merge tries to graft in as if they were real components and crashes
-  # on. Filter every dependsOn list (and drop whole dependency entries whose
-  # own ref isn't a real component) down to just what's actually backed by a
-  # component - the versioned module itself, or one of its real dependencies.
-  jq --arg old "${modulePurl}" --arg new "${versionedModule}" --arg version "${version}" '
-    (.. | select(. == $old)) = $new
-    | (.components[]? | select(."bom-ref" == $new)) |= (. + {"version": $version})
-    | (([.components[]?."bom-ref"] + [$new]) | unique) as $valid
-    | .dependencies = [
-        .dependencies[]?
-        | select(.ref as $r | $valid | index($r))
-        | .dependsOn = [(.dependsOn // [])[] | select(. as $d | $valid | index($d))]
-      ]
-  ' raw.json > versioned.json
+    # A source tree full of its own embedded test fixtures (e.g. trivy's own
+    # repo, full of testdata go.mod/package.json/etc fixtures for its own
+    # analyzer tests) makes trivy's fs scan produce a mess of synthetic
+    # intermediate grouping nodes - referenced from .dependencies but with no
+    # matching entry in .components at all. Left in, these become dangling refs
+    # our merge tries to graft in as if they were real components and crashes
+    # on. Filter every dependsOn list (and drop whole dependency entries whose
+    # own ref isn't a real component) down to just what's actually backed by a
+    # component - the versioned module itself, or one of its real dependencies.
+    jq --arg old "${modulePurl}" --arg new "${versionedModule}" --arg version "${version}" '
+      (.. | select(. == $old)) = $new
+      | (.components[]? | select(."bom-ref" == $new)) |= (. + {"version": $version})
+      | (([.components[]?."bom-ref"] + [$new]) | unique) as $valid
+      | .dependencies = [
+          .dependencies[]?
+          | select(.ref as $r | $valid | index($r))
+          | .dependsOn = [(.dependsOn // [])[] | select(. as $d | $valid | index($d))]
+        ]
+    ' raw.json > versioned.json
 
-  ${lib.concatMapStringsSep "\n" ({ name, binPath }:
-    let binRef = lib.removePrefix "/" binPath; in ''
-    jq --argjson externalReferences '${externalReferencesJson}' '
-      .metadata.component = {"type": "application", "bom-ref": "${binRef}", "name": "${binRef}"}
-      | .dependencies += [{"ref": "${binRef}", "dependsOn": ["${versionedModule}"]}]
-      | if ($externalReferences | length) > 0 then .externalReferences = ((.externalReferences // []) + $externalReferences) else . end
-    ' versioned.json > $out/sboms/${name}.json
-  '') binaries}
-''
+    ${lib.concatMapStringsSep "\n" (
+      { name, binPath }:
+      let
+        binRef = lib.removePrefix "/" binPath;
+      in
+      ''
+        jq --argjson externalReferences '${externalReferencesJson}' '
+          .metadata.component = {"type": "application", "bom-ref": "${binRef}", "name": "${binRef}"}
+          | .dependencies += [{"ref": "${binRef}", "dependsOn": ["${versionedModule}"]}]
+          | if ($externalReferences | length) > 0 then .externalReferences = ((.externalReferences // []) + $externalReferences) else . end
+        ' versioned.json > $out/sboms/${name}.json
+      ''
+    ) binaries}
+  ''

--- a/nix/trivy.nix
+++ b/nix/trivy.nix
@@ -74,7 +74,7 @@ in
     toolName = "trivy";
     src = sbomSrc;
     inherit version modulePurl;
-    goModules = package.goModules;
+    inherit (package) goModules;
     binaries = [{ name = "trivy"; binPath = "${package}/bin/trivy"; }];
   };
 }

--- a/nix/trivy.nix
+++ b/nix/trivy.nix
@@ -1,6 +1,13 @@
 # Upstream nixpkgs definition:
 # https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/by-name/tr/trivy/package.nix
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, runCommand, jq }:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  runCommand,
+  jq,
+}:
 
 let
   pname = "trivy";
@@ -75,6 +82,11 @@ in
     src = sbomSrc;
     inherit version modulePurl;
     inherit (package) goModules;
-    binaries = [{ name = "trivy"; binPath = "${package}/bin/trivy"; }];
+    binaries = [
+      {
+        name = "trivy";
+        binPath = "${package}/bin/trivy";
+      }
+    ];
   };
 }


### PR DESCRIPTION
This PR does:

- run statix (nix code analysis), run deadnix (drops dead code), nixfmt (formats nix code)
- adds treefmt, a meta-formatter that runs these 3 tools in 3 scenarios:
  - developer runs `nix fmt`
  - developer uses nix-shell and runs `treefmt`
  - CI runs `nix flake check` with the new github action and runs it as part of the checks

did not do that here but this leaves potential for:

- CI check could also push to the cache
- the treefmt config could also run go formatters/linters and other tools (markdown linters, etc. etc.)


This PR contains *no semantic changes*. Everything should stay untouched.