### PR TITLE
fix: generate the try-it encryption key without a backslash escape

### DIFF
--- a/docker-compose-try-it.yaml
+++ b/docker-compose-try-it.yaml
@@ -18,7 +18,7 @@ services:
         BASE=https://raw.githubusercontent.com/l3montree-dev/devguard/refs/heads/main &&
 
         if [ ! -f /keys/app_side_encryption.key ]; then
-          od -vN 32 -An -tx1 /dev/urandom | tr -d ' \n' > /keys/app_side_encryption.key &&
+          od -vN 32 -An -tx1 /dev/urandom | tr -dc '0-9a-f' > /keys/app_side_encryption.key &&
           echo 'Generated new encryption key.';
         else
           echo 'Encryption key already exists, skipping.';


### PR DESCRIPTION
Fixes #2841.

`docker-compose-try-it.yaml` line 21 writes the app-side encryption key with

```sh
od -vN 32 -An -tx1 /dev/urandom | tr -d ' \n'
```

On Docker Compose before v5.2.0 the `\n` never reaches `tr` as a newline. A
`command:` given as a string is split by `shellwords.Parse` (compose-go,
`types/command.go`), and go-shellwords v1.0.12 — the version in every Compose `go.mod`
I read from v2.20.0 through v5.1.0 (10 tags) —
drops the backslash and keeps the letter. The container runs `tr -d ' n'`, which deletes
spaces and the letter `n` and leaves `od`'s two line breaks in the file. go-shellwords
v1.0.13 turns the same escape into a real newline instead, and Compose picked that up in
v5.2.0; that is why the result depends on which binary you run, and why the same
command typed into `docker run alpine` is fine.

Measured by feeding this file's own `command:` scalar through `shellwords.Parse` at each
version and executing the argv it produces under busybox `sh`:

```text
shellwords   file          key size   line breaks
v1.0.12      as-is         66 bytes   2
v1.0.13      as-is         64 bytes   0
v1.0.12      this patch    64 bytes   0
v1.0.13      this patch    64 bytes   0
```

The 66-byte key is what takes the API down. `buildGCM`
(`services/db_encryption_service.go`) calls `bytes.TrimSpace`, which removes the trailing
newline only; the one at offset 32 stays, and `hex.Decode` then returns
`encoding/hex: invalid byte: U+000A` after 16 of 32 bytes, so `LoadDBEncryptionKey` panics on startup.

The patch replaces the escape rather than repairing it. `tr -dc '0-9a-f'` keeps only hex
digits and contains no backslash, so no YAML, Compose or shell layer can change its
meaning — the table above shows it is correct under both parser generations. It is also
strictly tighter than the original: nothing but a hex digit can enter the key whatever
`od` emits.

One line, one token. Nothing else in the file is touched, and the pattern does not occur
anywhere else in the repository.

Written by an automated agent. Every figure above is a command re-run by the script that
opened this pull request, not a recollection; it refuses to open if any of them drifts.
