### PR TITLE
fix: batch GetDependencyVulnsByOtherAssetVersions so its preloads stay under Postgres' parameter limit

### DIFF
--- a/database/repositories/dependency_vuln_repository.go
+++ b/database/repositories/dependency_vuln_repository.go
@@ -104,6 +104,17 @@ func (repository *dependencyVulnRepository) GetDependencyVulnsByAssetVersion(ctx
 	return dependencyVulns, nil
 }
 
+// otherAssetVersionsBatchSize bounds how many rows GetDependencyVulnsByOtherAssetVersions
+// materializes per round trip.
+//
+// GORM resolves a Preload with a single `... IN (?, ?, ...)` carrying one bind parameter
+// per parent row already fetched - the same behaviour getAllOpenVulns documents above.
+// Postgres' extended protocol caps a statement at 65535 bind parameters, so an asset whose
+// other versions hold more vulns than that fails with "extended protocol limited to 65535
+// parameters" inside the Events preload, not in the Where below. Batching the parents
+// bounds every preload issued for them.
+const otherAssetVersionsBatchSize = 1000
+
 func (repository *dependencyVulnRepository) GetDependencyVulnsByOtherAssetVersions(ctx context.Context, tx *gorm.DB, assetVersionName string, assetID uuid.UUID) ([]models.DependencyVuln, error) {
 	var dependencyVulns = []models.DependencyVuln{}
 
@@ -111,9 +122,14 @@ func (repository *dependencyVulnRepository) GetDependencyVulnsByOtherAssetVersio
 		return db.Order("created_at ASC")
 	}).Preload("CVE").Preload("CVE.Exploits").Where("dependency_vulns.asset_version_name != ? AND dependency_vulns.asset_id = ?", assetVersionName, assetID)
 
-	if err := q.Find(&dependencyVulns).Error; err != nil {
+	var batch []models.DependencyVuln
+	if err := q.FindInBatches(&batch, otherAssetVersionsBatchSize, func(*gorm.DB, int) error {
+		dependencyVulns = append(dependencyVulns, batch...)
+		return nil
+	}).Error; err != nil {
 		return nil, err
 	}
+
 	return dependencyVulns, nil
 }
 


### PR DESCRIPTION
Fixes #2857.

### The ceiling is reached in the preload, not in the query at `:107`

The `Where` on that line binds exactly two parameters — `assetVersionName` and `assetID` —
however many rows match. What scales with the row count is the `Preload` gorm runs
afterwards as a separate statement.

`callbacks/preload.go` (v1.31.2) collects the identity value of every parent row already
fetched and builds one `clause.IN` from all of them — `schema.ToQueryValues(...)` then
`tx.Where(clause.IN{Column: column, Values: values}).Find(...)`. `Preload("Events")` keys
on the `dependency_vulns` primary key, so that IN list carries **one bind parameter per row
returned**, and Postgres' extended protocol caps a statement at 65535 of them.

This shape is already documented one function down in the same file — `getAllOpenVulns`
loads artifacts manually rather than by `Preload` to avoid *"GORM's Preload building a
literal IN(...) list of every already-fetched vuln ID"*. `GetDependencyVulnsByOtherAssetVersions`
never got the same treatment, and it is the one that reads *every other version* of an
asset, so it is the one whose parent set grows with branch history.

### The change

`FindInBatches` at 1000, which keyset-paginates on the primary key and re-runs the
preloads per batch, so every IN list is bounded by the batch size instead of by the table.
The `Where`, the preloads and the returned slice are unchanged.

Measured against the real method with 2500 matching rows, two events each:

| | Events preload statements | bind parameters each |
|---|---|---|
| before | 1 | 2500 |
| after | 3 | 1000 / 1000 / 500 |

Both return the same 2500 rows and the same 5000 events. The patched run also asserts
that no row is dropped or duplicated at a batch boundary and that the 74 rows
outside the filter stay out.

The caller — `handleScanResult` — indexes the result by hash and filters it, so the
`ORDER BY id` that `FindInBatches` adds does not change any behaviour downstream.

**What I could not check here, stated plainly:** I have no Postgres to reproduce the 65535
error itself against, so the parameter ceiling is taken from Postgres' protocol limit and
the per-row IN list is what I measured. The measurement above ran on pure-Go SQLite
(`glebarez/sqlite`, already in your module graph). I have not shipped it as a test, because
that would promote an indirect dependency to a direct one to add one file, and the existing
sqlite test in this package uses the cgo driver, which I cannot build. If you want that test
in the tree, tell me which driver you would accept and I will push it to this branch.

### Two things next to this that I did not touch

**The same pattern is in five sibling functions in this file** — `GetByAssetID`, `GetDependencyVulnsByAssetVersion`, `GetDependencyVulnsByDefaultAssetVersion`, `ListByAssetAndAssetVersion`, `ListUnfixedByAssetAndAssetVersion` — each with an
unbatched `Preload("Events")`. `ListByAssetAndAssetVersion` is called from
`handleScanResult` immediately before this one, so a single branch large enough fails the
same way. I left them alone: the issue names one function, and turning a crash report
into a five-function refactor makes it unreviewable.

**The batching this file already has is switched off at every call site.**
`GetAllOpenVulnsByAssetID` and `GetAllOpenVulnsByAssetIDWithoutEvents` take a `batchSize`,
and all 5 callers pass `-1`, which the function's own comment reads as "no limit".
Those paths preload `Events` and `CVE` over every open vuln of an asset in one statement,
so they carry the same exposure with the remedy already written and unused.

One more thing worth a second opinion rather than a patch: `getAllOpenVulns` paginates with
`Limit`/`Offset` under `ORDER BY cve_id, vulnerability_path, created_at`, which is not
unique. Ties can be ordered differently between two statements, which lets a row be skipped
or repeated across a page boundary. I used `FindInBatches` here instead partly for that
reason.

Written by an automated agent. Every figure above is produced by the script that opened
this pull request, which re-runs the measurement and refuses to open if anything drifts.
