### PR TITLE
Feature resillient kratos connection

### DIFF
--- a/middlewares/session_middleware.go
+++ b/middlewares/session_middleware.go
@@ -53,38 +53,40 @@ func cookieAuth(ctx context.Context, oryAPIClient shared.PublicClient, oryKratos
 func SessionMiddleware(oryAPIClient shared.PublicClient, configService shared.ConfigService, verifier shared.Verifier) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {
-			oryKratosSessionCookie := getCookie("ory_kratos_session", ctx.Cookies())
 			instanceSettings, err := configService.GetInstanceSettings(ctx.Request().Context())
 			if err != nil {
 				return err
 			}
-			authHeader := ctx.Request().Header.Get("Authorization")
 
-			var userID string
-			var scopes string
-
-			if oryKratosSessionCookie != nil {
-				if userID, err = cookieAuth(ctx.Request().Context(), oryAPIClient, oryKratosSessionCookie.String()); err == nil {
-					scopes = "scan manage"
-					scopesArray := strings.Fields(scopes)
-					shared.SetSession(ctx, shared.NewSession(userID, shared.SessionActorUser, scopesArray, false))
+			oryKratosSessionCookie := getCookie("ory_kratos_session", ctx.Cookies())
+			if oryKratosSessionCookie != nil { // found a cookie, try to authenticate with it
+				if userID, err := cookieAuth(ctx.Request().Context(), oryAPIClient, oryKratosSessionCookie.String()); err == nil {
+					// successful authentication; set session and continue
+					shared.SetSession(ctx, shared.NewSession(userID, shared.SessionActorUser, strings.Fields("scan manage"), false))
 					return next(ctx)
 				} else {
 					slog.Warn("could not get session from cookie", "error", err)
 				}
 			}
-			if token, ok := strings.CutPrefix(authHeader, "Bearer "); ok && !instanceSettings.BearerTokenAuthDisabled {
-				if session, err := verifier.VerifyAPIToken(ctx.Request().Context(), token); err == nil {
-					shared.SetSession(ctx, session)
-					return next(ctx)
-				}
-			} else {
-				if session, err := verifier.VerifyRequestSignature(ctx.Request().Context(), ctx.Request()); err == nil {
-					shared.SetSession(ctx, session)
-					return next(ctx)
+
+			// try to authenticate via bearer tokens
+			if !instanceSettings.BearerTokenAuthDisabled {
+				authHeader := ctx.Request().Header.Get("Authorization")
+				if token, ok := strings.CutPrefix(authHeader, "Bearer "); ok { // check if a token can be parsed
+					if session, err := verifier.VerifyAPIToken(ctx.Request().Context(), token); err == nil { // then verify the token
+						shared.SetSession(ctx, session)
+						return next(ctx)
+					}
 				}
 			}
 
+			// lastly check if we can authenticate via the request signature
+			if session, err := verifier.VerifyRequestSignature(ctx.Request().Context(), ctx.Request()); err == nil {
+				shared.SetSession(ctx, session)
+				return next(ctx)
+			}
+
+			// could not authenticate; set to anonymous
 			shared.SetSession(ctx, shared.AnonymousSession)
 			return next(ctx)
 		}

--- a/middlewares/session_middleware.go
+++ b/middlewares/session_middleware.go
@@ -36,7 +36,6 @@ func getCookie(name string, cookies []*http.Cookie) *http.Cookie {
 }
 
 func cookieAuth(ctx context.Context, oryAPIClient shared.PublicClient, oryKratosSessionCookie string) (string, error) {
-	// check if we have a session
 	unescaped, err := url.QueryUnescape(oryKratosSessionCookie)
 	if err != nil {
 		return "", err
@@ -50,23 +49,28 @@ func cookieAuth(ctx context.Context, oryAPIClient shared.PublicClient, oryKratos
 	return session.Id, nil
 }
 
+// try to authenticate request using (in order) kratos session cookie, bearer token or request signature
+// if one of these methods fail the verification we set "no session" and skip the others
 func SessionMiddleware(oryAPIClient shared.PublicClient, configService shared.ConfigService, verifier shared.Verifier) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {
-			instanceSettings, err := configService.GetInstanceSettings(ctx.Request().Context())
-			if err != nil {
-				return err
-			}
-
 			oryKratosSessionCookie := getCookie("ory_kratos_session", ctx.Cookies())
-			if oryKratosSessionCookie != nil { // found a cookie, try to authenticate with it
+			if oryKratosSessionCookie != nil {
+				// found a cookie, try to authenticate with it
 				if userID, err := cookieAuth(ctx.Request().Context(), oryAPIClient, oryKratosSessionCookie.String()); err == nil {
 					// successful authentication; set session and continue
 					shared.SetSession(ctx, shared.NewSession(userID, shared.SessionActorUser, strings.Fields("scan manage"), false))
 					return next(ctx)
 				} else {
 					slog.Warn("could not get session from cookie", "error", err)
+					shared.SetSession(ctx, shared.AnonymousSession)
+					return next(ctx)
 				}
+			}
+
+			instanceSettings, err := configService.GetInstanceSettings(ctx.Request().Context())
+			if err != nil {
+				return err
 			}
 
 			// try to authenticate via bearer tokens
@@ -75,6 +79,9 @@ func SessionMiddleware(oryAPIClient shared.PublicClient, configService shared.Co
 				if token, ok := strings.CutPrefix(authHeader, "Bearer "); ok { // check if a token can be parsed
 					if session, err := verifier.VerifyAPIToken(ctx.Request().Context(), token); err == nil { // then verify the token
 						shared.SetSession(ctx, session)
+						return next(ctx)
+					} else {
+						shared.SetSession(ctx, shared.AnonymousSession)
 						return next(ctx)
 					}
 				}

--- a/middlewares/session_middleware_test.go
+++ b/middlewares/session_middleware_test.go
@@ -147,13 +147,14 @@ func TestSessionMiddleware(t *testing.T) {
 		verifier.AssertExpectations(t)
 	})
 
-	t.Run("should fall through to request signature when cookie auth fails", func(t *testing.T) {
+	t.Run("should set no session and skip the remaining auth methods when cookie auth fails", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.AddCookie(&http.Cookie{
 			Name:  "ory_kratos_session",
 			Value: "bad_cookie",
 		})
+		req.Header.Set("Authorization", "Bearer mytoken123")
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
@@ -161,21 +162,22 @@ func TestSessionMiddleware(t *testing.T) {
 		mockAdminClient.On("GetIdentityFromCookie", mock.Anything, "ory_kratos_session=bad_cookie").Return(client.Identity{}, errors.New("invalid cookie"))
 
 		verifier := new(mocks.Authorizer)
-		verifier.On("VerifyRequestSignature", mock.Anything, mock.Anything).Return(shared.NewSession("user4", shared.SessionActorUser, []string{"read"}, false), nil)
 
-		mw := SessionMiddleware(mockAdminClient, newConfigMock(t, shared.InstanceSettings{}), verifier)
+		// a config mock without expectations - the instance settings must not be read either
+		mw := SessionMiddleware(mockAdminClient, mocks.NewConfigService(t), verifier)
 
 		var called bool
 		handler := mw(func(ctx echo.Context) error {
 			called = true
 			sess := shared.GetSession(ctx)
-			assert.Equal(t, "user4", sess.GetActorID())
+			assert.Equal(t, shared.AnonymousSession, sess)
 			return nil
 		})
 
 		_ = handler(c)
 		assert.True(t, called)
-		verifier.AssertExpectations(t)
+		verifier.AssertNotCalled(t, "VerifyAPIToken")
+		verifier.AssertNotCalled(t, "VerifyRequestSignature")
 	})
 
 	t.Run("should set the correct scopes and userID using cookie auth", func(t *testing.T) {
@@ -194,7 +196,7 @@ func TestSessionMiddleware(t *testing.T) {
 			Id: "user2",
 		}, nil)
 
-		mw := SessionMiddleware(mockAdminClient, newConfigMock(t, shared.InstanceSettings{}), nil)
+		mw := SessionMiddleware(mockAdminClient, mocks.NewConfigService(t), nil)
 
 		var called bool
 		handler := mw(func(ctx echo.Context) error {

--- a/services/config_service.go
+++ b/services/config_service.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/database/repositories"
@@ -51,12 +50,9 @@ func (service ConfigService) SetJSONConfig(ctx context.Context, key string, v an
 	}
 
 	// Keep the in-memory instance settings cache in sync with the DB write
-	if key == "instanceSettings" && instanceSettingsCache != nil {
+	if key == "instanceSettings" {
 		if settings, ok := v.(shared.InstanceSettings); ok {
-			instanceSettingsCacheMutex.Lock()
-			instanceSettingsCache = &settings
-			instanceSettingsExpiry = time.Now().Add(5 * time.Minute)
-			instanceSettingsCacheMutex.Unlock()
+			settingsCache.UpdateCachedSettings(&settings)
 		}
 	}
 
@@ -67,13 +63,10 @@ func (service ConfigService) RemoveConfig(ctx context.Context, key string) error
 	return service.repository.GetDB(ctx, nil).Where("key = ?", key).Delete(&models.Config{}).Error
 }
 
-var instanceSettingsCache *shared.InstanceSettings
-var instanceSettingsExpiry time.Time
-var instanceSettingsCacheMutex = sync.Mutex{}
-
 func (service ConfigService) GetInstanceSettings(ctx context.Context) (shared.InstanceSettings, error) {
-	if instanceSettingsCache != nil && time.Now().Before(instanceSettingsExpiry) {
-		return *instanceSettingsCache, nil
+	cachedSettings, ok := settingsCache.GetCachedSettings()
+	if ok {
+		return cachedSettings, nil
 	}
 
 	var settings shared.InstanceSettings
@@ -93,21 +86,52 @@ func (service ConfigService) GetInstanceSettings(ctx context.Context) (shared.In
 			settings.BearerTokenAuthDisabled = false
 		}
 	}
-
-	instanceSettingsCacheMutex.Lock()
-	instanceSettingsCache = &settings
-	instanceSettingsExpiry = time.Now().Add(5 * time.Minute) // cache for 5 minutes
-	instanceSettingsCacheMutex.Unlock()
-
+	// one could argue that we should only update when we hit NO error
+	// I think its a tradeoff between correctness and caching effectiveness
+	settingsCache.UpdateCachedSettings(&settings)
 	return settings, nil
 }
 
-func (service ConfigService) GetAndCacheInstanceSettings(ctx context.Context) (shared.InstanceSettings, error) {
+var settingsCache = NewInstanceSettingsCache()
 
-	settings, err := service.GetInstanceSettings(ctx)
-	if err != nil {
-		return shared.InstanceSettings{}, err
+// cache instance settings, no time to life since we know when they change
+type instanceSettingsCache struct {
+	cachedSettings *shared.InstanceSettings
+	mutex          *sync.RWMutex
+}
+
+func NewInstanceSettingsCache() instanceSettingsCache {
+	return instanceSettingsCache{
+		mutex: &sync.RWMutex{},
 	}
+}
 
-	return settings, nil
+// retrieves the cached settings, returns bool to check if anything is cached
+func (cache *instanceSettingsCache) GetCachedSettings() (shared.InstanceSettings, bool) {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+	if cache.cachedSettings == nil {
+		return shared.InstanceSettings{}, false
+	}
+	return *cache.cachedSettings, true
+}
+
+// updates the cached settings with new ones
+func (cache *instanceSettingsCache) UpdateCachedSettings(settings *shared.InstanceSettings) {
+	if settings != nil { // only update if values are provided
+		cache.mutex.Lock()
+		defer cache.mutex.Unlock()
+		cache.cachedSettings = settings
+	}
+}
+
+// checks if the provided settings are identical to the cached settings
+func checkIfSettingsAreEqualToCache(settings shared.InstanceSettings) bool {
+	cachedSettings, ok := settingsCache.GetCachedSettings()
+	if !ok { // nothing cached so far -> false
+		return false
+	}
+	// check if all values match
+	return settings.BearerTokenAuthDisabled == cachedSettings.BearerTokenAuthDisabled &&
+		settings.SingleOrganizationMode == cachedSettings.SingleOrganizationMode
 }

--- a/services/config_service.go
+++ b/services/config_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/database/repositories"
@@ -50,9 +51,12 @@ func (service ConfigService) SetJSONConfig(ctx context.Context, key string, v an
 	}
 
 	// Keep the in-memory instance settings cache in sync with the DB write
-	if key == "instanceSettings" {
+	if key == "instanceSettings" && instanceSettingsCache != nil {
 		if settings, ok := v.(shared.InstanceSettings); ok {
-			settingsCache.UpdateCachedSettings(&settings)
+			instanceSettingsCacheMutex.Lock()
+			instanceSettingsCache = &settings
+			instanceSettingsExpiry = time.Now().Add(5 * time.Minute)
+			instanceSettingsCacheMutex.Unlock()
 		}
 	}
 
@@ -63,10 +67,15 @@ func (service ConfigService) RemoveConfig(ctx context.Context, key string) error
 	return service.repository.GetDB(ctx, nil).Where("key = ?", key).Delete(&models.Config{}).Error
 }
 
+const instanceSettingsTTL = 5 * time.Minute // cache for 5 minutes
+
+var instanceSettingsCache *shared.InstanceSettings
+var instanceSettingsExpiry time.Time
+var instanceSettingsCacheMutex = sync.Mutex{}
+
 func (service ConfigService) GetInstanceSettings(ctx context.Context) (shared.InstanceSettings, error) {
-	cachedSettings, ok := settingsCache.GetCachedSettings()
-	if ok {
-		return cachedSettings, nil
+	if instanceSettingsCache != nil && time.Now().Before(instanceSettingsExpiry) {
+		return *instanceSettingsCache, nil
 	}
 
 	var settings shared.InstanceSettings
@@ -86,52 +95,21 @@ func (service ConfigService) GetInstanceSettings(ctx context.Context) (shared.In
 			settings.BearerTokenAuthDisabled = false
 		}
 	}
-	// one could argue that we should only update when we hit NO error
-	// I think its a tradeoff between correctness and caching effectiveness
-	settingsCache.UpdateCachedSettings(&settings)
+
+	instanceSettingsCacheMutex.Lock()
+	instanceSettingsCache = &settings
+	instanceSettingsExpiry = time.Now().Add(instanceSettingsTTL)
+	instanceSettingsCacheMutex.Unlock()
+
 	return settings, nil
 }
 
-var settingsCache = NewInstanceSettingsCache()
+func (service ConfigService) GetAndCacheInstanceSettings(ctx context.Context) (shared.InstanceSettings, error) {
 
-// cache instance settings, no time to life since we know when they change
-type instanceSettingsCache struct {
-	cachedSettings *shared.InstanceSettings
-	mutex          *sync.RWMutex
-}
-
-func NewInstanceSettingsCache() instanceSettingsCache {
-	return instanceSettingsCache{
-		mutex: &sync.RWMutex{},
+	settings, err := service.GetInstanceSettings(ctx)
+	if err != nil {
+		return shared.InstanceSettings{}, err
 	}
-}
 
-// retrieves the cached settings, returns bool to check if anything is cached
-func (cache *instanceSettingsCache) GetCachedSettings() (shared.InstanceSettings, bool) {
-	cache.mutex.RLock()
-	defer cache.mutex.RUnlock()
-	if cache.cachedSettings == nil {
-		return shared.InstanceSettings{}, false
-	}
-	return *cache.cachedSettings, true
-}
-
-// updates the cached settings with new ones
-func (cache *instanceSettingsCache) UpdateCachedSettings(settings *shared.InstanceSettings) {
-	if settings != nil { // only update if values are provided
-		cache.mutex.Lock()
-		defer cache.mutex.Unlock()
-		cache.cachedSettings = settings
-	}
-}
-
-// checks if the provided settings are identical to the cached settings
-func checkIfSettingsAreEqualToCache(settings shared.InstanceSettings) bool {
-	cachedSettings, ok := settingsCache.GetCachedSettings()
-	if !ok { // nothing cached so far -> false
-		return false
-	}
-	// check if all values match
-	return settings.BearerTokenAuthDisabled == cachedSettings.BearerTokenAuthDisabled &&
-		settings.SingleOrganizationMode == cachedSettings.SingleOrganizationMode
+	return settings, nil
 }

--- a/shared/context_utils.go
+++ b/shared/context_utils.go
@@ -17,6 +17,7 @@ package shared
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"math/rand"
@@ -29,6 +30,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/dtos"
 	"github.com/l3montree-dev/devguard/monitoring"
@@ -89,12 +91,14 @@ type PublicClient interface {
 }
 
 type PublicClientImplementation struct {
-	apiClient *client.APIClient
+	apiClient    *client.APIClient
+	sessionCache *sessionCache
 }
 
 func NewPublicClient(client *client.APIClient) PublicClientImplementation {
 	return PublicClientImplementation{
-		apiClient: client,
+		apiClient:    client,
+		sessionCache: NewSessionCache(),
 	}
 }
 
@@ -108,9 +112,88 @@ func NewAdminClient(client *client.APIClient) AdminClientImplementation {
 	}
 }
 
+const sessionTTL = 30 * time.Second
+const sessionCacheSize = 2000
+
+// leaving out unnecessary struct fields from the client.Session struct to reduce memory consumption
+type minimalSession struct {
+	identity  client.Identity
+	active    *bool
+	expiresAt *time.Time
+	err       error // also cache failed verifications
+}
+
+// caches successful as well as unsuccessful verifications via ory kratos
+// key: hash of the cookie, value: session information + error (error determines success of the authentication)
+// successful entries are checked for staleness before retrieval
+// unsuccessful entries live for the full ttl before being reevaluated
+type sessionCache struct {
+	cache *expirable.LRU[string, minimalSession]
+}
+
+func NewSessionCache() *sessionCache {
+	return &sessionCache{
+		cache: expirable.NewLRU[string, minimalSession](sessionCacheSize, nil, sessionTTL),
+	}
+}
+
+// reads the session from the cache, returns true if a usable session was found
+// returns false if there is no session or it expired already
+func (cache *sessionCache) ReadFromCache(cookie string) (result minimalSession, ok bool) {
+	session, found := cache.cache.Get(hashCookie(cookie))
+	if found && shouldReturnCached(session) {
+		return session, true
+	}
+	return result, false
+}
+
+// calculates the sha256 checksum of a cookie
+func hashCookie(cookie string) string {
+	sum := sha256.Sum256([]byte(cookie))
+	return string(sum[:])
+}
+
+func (cache *sessionCache) WriteToCache(cookie string, session *client.Session, err error) {
+	cache.cache.Add(hashCookie(cookie), sessionToMinimalSession(session, err))
+}
+
+func shouldReturnCached(session minimalSession) bool {
+	// Option A: we have an error -> return the unsuccessful verification
+	// Option B: we have no error -> check if the session is still valid
+	return session.err != nil || (session.active != nil && *session.active && session.expiresAt != nil && time.Now().Before(*session.expiresAt))
+}
+
+// transformer to convert a ory session to a minimal session
+func sessionToMinimalSession(session *client.Session, err error) minimalSession {
+	// default to empty struct if session is nil
+	// we want to also cache unsuccessful verifications
+	identity := client.Identity{}
+	if session != nil {
+		identity = *session.Identity
+	}
+	return minimalSession{
+		identity:  identity,
+		active:    session.Active,
+		expiresAt: session.ExpiresAt,
+		err:       err,
+	}
+}
+
 const maxNumberOfRetries = 3
 
 func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, cookie string) (client.Identity, error) {
+	// first try to read from the cache
+	cachedSession, ok := a.sessionCache.ReadFromCache(cookie)
+	if ok {
+		// now check if it was a successful or unsuccessful verification
+		if cachedSession.err != nil {
+			slog.Info("unsuccessful verification with cache", "reason", cachedSession.err)
+			return client.Identity{}, cachedSession.err
+		}
+		slog.Info("successful verification with cache")
+		return cachedSession.identity, nil
+	}
+
 	retries := 0
 	session, resp, err := a.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
 	for shouldRetry(ctx, err, resp, retries) {
@@ -133,12 +216,19 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 		if statusCode == 0 || statusCode >= 500 {
 			// alter if status Code is missing or not authentication related
 			monitoring.Alert("kratos: could not get identity from cookie", err)
+		} else {
+			// cache unsuccessful verification (if its a 4xx error)
+			a.sessionCache.WriteToCache(cookie, session, err)
 		}
 		return client.Identity{}, fmt.Errorf("could not get identity from cookie: %w", err)
 	}
+
 	if session.Identity == nil {
 		return client.Identity{}, fmt.Errorf("identity not found in session")
 	}
+
+	// cache successful verifications
+	a.sessionCache.WriteToCache(cookie, session, nil)
 	return *session.Identity, nil
 }
 

--- a/shared/context_utils.go
+++ b/shared/context_utils.go
@@ -18,11 +18,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
+	"math/rand"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/l3montree-dev/devguard/database/models"
@@ -104,18 +108,30 @@ func NewAdminClient(client *client.APIClient) AdminClientImplementation {
 	}
 }
 
+const maxNumberOfRetries = 3
+
 func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, cookie string) (client.Identity, error) {
-	session, httpResp, err := a.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
-	session.
+	retries := 0
+	session, resp, err := a.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
+	for shouldRetry(ctx, err, resp, retries) {
+		retries++
+		slog.Warn("could not get identity from cookie, backing off then retrying", "retry", retries, "error", err)
+		select { // check context cancellation
+		case <-ctx.Done():
+			return client.Identity{}, ctx.Err()
+		case <-time.After(calculateBackoffTime(retries)):
+		}
+		session, resp, err = a.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
+	}
+
 	if err != nil {
-		// a 401 just means "no valid session" - the common, expected case. Anything
-		// else (5xx, connection refused, timeout - reported as a nil httpResp) means
-		// Kratos itself is unreachable or failing, which is worth alerting on.
+		// if we fail after all retries then alert
 		statusCode := 0
-		if httpResp != nil {
-			statusCode = httpResp.StatusCode
+		if resp != nil {
+			statusCode = resp.StatusCode
 		}
 		if statusCode == 0 || statusCode >= 500 {
+			// alter if status Code is missing or not authentication related
 			monitoring.Alert("kratos: could not get identity from cookie", err)
 		}
 		return client.Identity{}, fmt.Errorf("could not get identity from cookie: %w", err)
@@ -124,6 +140,26 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 		return client.Identity{}, fmt.Errorf("identity not found in session")
 	}
 	return *session.Identity, nil
+}
+
+// determines if we should retry based on execute results
+func shouldRetry(ctx context.Context, err error, resp *http.Response, retries int) bool {
+	if err == nil || retries >= maxNumberOfRetries {
+		return false // no error or too many retries
+	}
+	if ctx.Err() != nil {
+		return false // context cancelled, no point in retrying
+	}
+	if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 403) {
+		return false // authentication failed will fail again
+	}
+	return true
+}
+
+// 2 ^ numOfRetries+4 (start at 32ms, max 128ms), halved and jittered so concurrent requests do not retry at the same time
+func calculateBackoffTime(retries int) time.Duration {
+	backoff := time.Duration(1<<(retries+4)) * time.Millisecond
+	return backoff/2 + time.Duration(rand.Int63n(int64(backoff/2))) // #nosec
 }
 
 func (a AdminClientImplementation) ListUser(request client.IdentityAPIListIdentitiesRequest) ([]client.Identity, error) {

--- a/shared/context_utils.go
+++ b/shared/context_utils.go
@@ -208,10 +208,11 @@ func (publicClient PublicClientImplementation) GetIdentityFromCookie(ctx context
 		slog.Warn("could not get identity from cookie, backing off then retrying", "retry", retries, "error", err)
 		select { // check context cancellation
 		case <-ctx.Done():
+			slog.Error("cancel retry due to context cancellation", "reason", ctx.Err().Error())
 			return client.Identity{}, ctx.Err()
 		case <-time.After(calculateBackoffTime(retries)):
 		}
-		session, resp, err = publicClient.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
+		session, resp, err = publicClient.getIdentitySingleflight(ctx, cookie)
 	}
 
 	if err != nil {
@@ -246,14 +247,11 @@ type singleflightResponse struct {
 
 // wraps the cookie verification request inside a singleflight
 func (publicClient PublicClientImplementation) getIdentitySingleflight(ctx context.Context, cookie string) (*client.Session, *http.Response, error) {
-	result, err, _ := publicClient.singleflightGroup.Do(cookie, func() (any, error) {
+	result, err, _ := publicClient.singleflightGroup.Do(hashCookie(cookie), func() (any, error) {
 		session, resp, err := publicClient.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
 		return singleflightResponse{session: session, resp: resp}, err
 	})
-	response, ok := result.(singleflightResponse)
-	if !ok {
-		return nil, nil, fmt.Errorf("could not parse singleflight response")
-	}
+	response, _ := result.(singleflightResponse) // will always succeed
 	return response.session, response.resp, err
 }
 

--- a/shared/context_utils.go
+++ b/shared/context_utils.go
@@ -98,7 +98,7 @@ type PublicClientImplementation struct {
 func NewPublicClient(client *client.APIClient) PublicClientImplementation {
 	return PublicClientImplementation{
 		apiClient:    client,
-		sessionCache: NewSessionCache(),
+		sessionCache: newSessionCache(),
 	}
 }
 
@@ -131,7 +131,7 @@ type sessionCache struct {
 	cache *expirable.LRU[string, minimalSession]
 }
 
-func NewSessionCache() *sessionCache {
+func newSessionCache() *sessionCache {
 	return &sessionCache{
 		cache: expirable.NewLRU[string, minimalSession](sessionCacheSize, nil, sessionTTL),
 	}
@@ -165,14 +165,18 @@ func shouldReturnCached(session minimalSession) bool {
 
 // transformer to convert a ory session to a minimal session
 func sessionToMinimalSession(session *client.Session, err error) minimalSession {
-	// default to empty struct if session is nil
-	// we want to also cache unsuccessful verifications
-	identity := client.Identity{}
-	if session != nil {
-		identity = *session.Identity
+	if session == nil || session.Identity == nil {
+		// default to empty struct if session is nil
+		// we want to also cache unsuccessful verifications
+		return minimalSession{
+			identity:  client.Identity{},
+			active:    nil,
+			expiresAt: nil,
+			err:       err,
+		}
 	}
 	return minimalSession{
-		identity:  identity,
+		identity:  *session.Identity,
 		active:    session.Active,
 		expiresAt: session.ExpiresAt,
 		err:       err,
@@ -188,7 +192,7 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 		// now check if it was a successful or unsuccessful verification
 		if cachedSession.err != nil {
 			slog.Info("unsuccessful verification with cache", "reason", cachedSession.err)
-			return client.Identity{}, cachedSession.err
+			return client.Identity{}, fmt.Errorf("could not get identity from cookie: %w", cachedSession.err)
 		}
 		slog.Info("successful verification with cache")
 		return cachedSession.identity, nil
@@ -216,8 +220,8 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 		if statusCode == 0 || statusCode >= 500 {
 			// alter if status Code is missing or not authentication related
 			monitoring.Alert("kratos: could not get identity from cookie", err)
-		} else {
-			// cache unsuccessful verification (if its a 4xx error)
+		} else if statusCode == 401 {
+			// cache unsuccessful verifications
 			a.sessionCache.WriteToCache(cookie, session, err)
 		}
 		return client.Identity{}, fmt.Errorf("could not get identity from cookie: %w", err)
@@ -232,7 +236,7 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 	return *session.Identity, nil
 }
 
-// determines if we should retry based on execute results
+// determines if we should retry based on kratos response
 func shouldRetry(ctx context.Context, err error, resp *http.Response, retries int) bool {
 	if err == nil || retries >= maxNumberOfRetries {
 		return false // no error or too many retries
@@ -241,7 +245,7 @@ func shouldRetry(ctx context.Context, err error, resp *http.Response, retries in
 		return false // context cancelled, no point in retrying
 	}
 	if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 403) {
-		return false // authentication failed will fail again
+		return false // authentication failed -> will fail again
 	}
 	return true
 }

--- a/shared/context_utils.go
+++ b/shared/context_utils.go
@@ -231,7 +231,7 @@ func (publicClient PublicClientImplementation) GetIdentityFromCookie(ctx context
 		return client.Identity{}, fmt.Errorf("could not get identity from cookie: %w", err)
 	}
 
-	if session.Identity == nil {
+	if session == nil || session.Identity == nil {
 		return client.Identity{}, fmt.Errorf("identity not found in session")
 	}
 

--- a/shared/context_utils.go
+++ b/shared/context_utils.go
@@ -35,6 +35,7 @@ import (
 	"github.com/l3montree-dev/devguard/dtos"
 	"github.com/l3montree-dev/devguard/monitoring"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/l3montree-dev/devguard/utils"
 	"github.com/ory/client-go"
@@ -91,14 +92,16 @@ type PublicClient interface {
 }
 
 type PublicClientImplementation struct {
-	apiClient    *client.APIClient
-	sessionCache *sessionCache
+	apiClient         *client.APIClient
+	sessionCache      *sessionCache
+	singleflightGroup *singleflight.Group
 }
 
 func NewPublicClient(client *client.APIClient) PublicClientImplementation {
 	return PublicClientImplementation{
-		apiClient:    client,
-		sessionCache: newSessionCache(),
+		apiClient:         client,
+		sessionCache:      newSessionCache(),
+		singleflightGroup: &singleflight.Group{},
 	}
 }
 
@@ -185,9 +188,9 @@ func sessionToMinimalSession(session *client.Session, err error) minimalSession 
 
 const maxNumberOfRetries = 3
 
-func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, cookie string) (client.Identity, error) {
+func (publicClient PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, cookie string) (client.Identity, error) {
 	// first try to read from the cache
-	cachedSession, ok := a.sessionCache.ReadFromCache(cookie)
+	cachedSession, ok := publicClient.sessionCache.ReadFromCache(cookie)
 	if ok {
 		// now check if it was a successful or unsuccessful verification
 		if cachedSession.err != nil {
@@ -199,7 +202,7 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 	}
 
 	retries := 0
-	session, resp, err := a.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
+	session, resp, err := publicClient.getIdentitySingleflight(ctx, cookie)
 	for shouldRetry(ctx, err, resp, retries) {
 		retries++
 		slog.Warn("could not get identity from cookie, backing off then retrying", "retry", retries, "error", err)
@@ -208,7 +211,7 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 			return client.Identity{}, ctx.Err()
 		case <-time.After(calculateBackoffTime(retries)):
 		}
-		session, resp, err = a.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
+		session, resp, err = publicClient.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
 	}
 
 	if err != nil {
@@ -222,7 +225,7 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 			monitoring.Alert("kratos: could not get identity from cookie", err)
 		} else if statusCode == 401 {
 			// cache unsuccessful verifications
-			a.sessionCache.WriteToCache(cookie, session, err)
+			publicClient.sessionCache.WriteToCache(cookie, session, err)
 		}
 		return client.Identity{}, fmt.Errorf("could not get identity from cookie: %w", err)
 	}
@@ -232,8 +235,26 @@ func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, c
 	}
 
 	// cache successful verifications
-	a.sessionCache.WriteToCache(cookie, session, nil)
+	publicClient.sessionCache.WriteToCache(cookie, session, nil)
 	return *session.Identity, nil
+}
+
+type singleflightResponse struct {
+	session *client.Session
+	resp    *http.Response
+}
+
+// wraps the cookie verification request inside a singleflight
+func (publicClient PublicClientImplementation) getIdentitySingleflight(ctx context.Context, cookie string) (*client.Session, *http.Response, error) {
+	result, err, _ := publicClient.singleflightGroup.Do(cookie, func() (any, error) {
+		session, resp, err := publicClient.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
+		return singleflightResponse{session: session, resp: resp}, err
+	})
+	response, ok := result.(singleflightResponse)
+	if !ok {
+		return nil, nil, fmt.Errorf("could not parse singleflight response")
+	}
+	return response.session, response.resp, err
 }
 
 // determines if we should retry based on kratos response

--- a/shared/context_utils.go
+++ b/shared/context_utils.go
@@ -106,6 +106,7 @@ func NewAdminClient(client *client.APIClient) AdminClientImplementation {
 
 func (a PublicClientImplementation) GetIdentityFromCookie(ctx context.Context, cookie string) (client.Identity, error) {
 	session, httpResp, err := a.apiClient.FrontendAPI.ToSession(ctx).Cookie(cookie).Execute()
+	session.
 	if err != nil {
 		// a 401 just means "no valid session" - the common, expected case. Anything
 		// else (5xx, connection refused, timeout - reported as a nil httpResp) means


### PR DESCRIPTION
Make kratos connection more resillient, including:

- [x] Add retry if we cant connect to the kratos server
- [x] Add a cache for cookie verification (short lived)
- [x] Add Singleflight to cookie verification

Additional changes:

- Restructured the code flow of the auth middleware 