### PR TITLE
Fix nil pointer in Asset.Same during external entity sync

### DIFF
--- a/database/models/asset_model.go
+++ b/database/models/asset_model.go
@@ -69,12 +69,15 @@ func (m Asset) TableName() string {
 }
 
 func (m *Asset) Same(other *Asset) bool {
-	if m.ExternalEntityID == nil || m.ExternalEntityProviderID == nil {
-		return m.ID != uuid.Nil && m.ID == other.ID
+	if m == nil || other == nil {
+		return m == other
 	}
 
-	return *m.ExternalEntityID == *other.ExternalEntityID &&
-		*m.ExternalEntityProviderID == *other.ExternalEntityProviderID
+	return sameExternalEntityOrID(
+		m.ID, other.ID,
+		m.ExternalEntityID, other.ExternalEntityID,
+		m.ExternalEntityProviderID, other.ExternalEntityProviderID,
+	)
 }
 
 func (m *Asset) GetSlug() string {

--- a/database/models/asset_model_test.go
+++ b/database/models/asset_model_test.go
@@ -1,0 +1,73 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssetSame(t *testing.T) {
+	externalID := "12471"
+	providerID := "opencode"
+	otherExternalID := "99999"
+	id := uuid.New()
+
+	t.Run("should return true for matching external identity", func(t *testing.T) {
+		a := &Asset{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		b := &Asset{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		assert.True(t, a.Same(b))
+	})
+
+	t.Run("should return false for different external identity", func(t *testing.T) {
+		a := &Asset{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		b := &Asset{ExternalEntityID: &otherExternalID, ExternalEntityProviderID: &providerID}
+		assert.False(t, a.Same(b))
+	})
+
+	t.Run("should not panic when other has no external identity", func(t *testing.T) {
+		a := &Asset{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		b := &Asset{Model: Model{ID: uuid.New()}}
+		assert.NotPanics(t, func() { a.Same(b) })
+		assert.False(t, a.Same(b))
+	})
+
+	t.Run("should not panic when receiver has no external identity", func(t *testing.T) {
+		a := &Asset{Model: Model{ID: uuid.New()}}
+		b := &Asset{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		assert.NotPanics(t, func() { a.Same(b) })
+		assert.False(t, a.Same(b))
+	})
+
+	t.Run("should fall back to id when neither has an external identity", func(t *testing.T) {
+		a := &Asset{Model: Model{ID: id}}
+		b := &Asset{Model: Model{ID: id}}
+		assert.True(t, a.Same(b))
+	})
+
+	t.Run("should return false for different ids without external identity", func(t *testing.T) {
+		a := &Asset{Model: Model{ID: uuid.New()}}
+		b := &Asset{Model: Model{ID: uuid.New()}}
+		assert.False(t, a.Same(b))
+	})
+
+	t.Run("should not panic when other is nil", func(t *testing.T) {
+		a := &Asset{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		assert.NotPanics(t, func() { a.Same(nil) })
+		assert.False(t, a.Same(nil))
+	})
+
+	t.Run("should not panic when receiver is nil", func(t *testing.T) {
+		var a *Asset
+		b := &Asset{Model: Model{ID: id}}
+		assert.NotPanics(t, func() { a.Same(b) })
+		assert.False(t, a.Same(b))
+	})
+
+	t.Run("should not panic when other has only one external field set", func(t *testing.T) {
+		a := &Asset{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		b := &Asset{ExternalEntityID: &externalID}
+		assert.NotPanics(t, func() { a.Same(b) })
+		assert.False(t, a.Same(b))
+	})
+}

--- a/database/models/model.go
+++ b/database/models/model.go
@@ -15,3 +15,14 @@ type Model struct {
 func (a Model) GetID() uuid.UUID {
 	return a.ID
 }
+
+func sameExternalEntityOrID(
+	id, otherID uuid.UUID,
+	externalID, otherExternalID,
+	providerID, otherProviderID *string,
+) bool {
+	if externalID != nil && providerID != nil && otherExternalID != nil && otherProviderID != nil {
+		return *externalID == *otherExternalID && *providerID == *otherProviderID
+	}
+	return id != uuid.Nil && id == otherID
+}

--- a/database/models/project_model.go
+++ b/database/models/project_model.go
@@ -62,12 +62,15 @@ func (m Project) IsExternalEntity() bool {
 }
 
 func (m *Project) Same(other *Project) bool {
-	if m.ExternalEntityID == nil || m.ExternalEntityProviderID == nil {
-		return m.ID != uuid.Nil && m.ID == other.ID
+	if m == nil || other == nil {
+		return m == other
 	}
 
-	return *m.ExternalEntityID == *other.ExternalEntityID &&
-		*m.ExternalEntityProviderID == *other.ExternalEntityProviderID
+	return sameExternalEntityOrID(
+		m.ID, other.ID,
+		m.ExternalEntityID, other.ExternalEntityID,
+		m.ExternalEntityProviderID, other.ExternalEntityProviderID,
+	)
 }
 
 func (m *Project) GetSlug() string {

--- a/database/models/project_model_test.go
+++ b/database/models/project_model_test.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectSame(t *testing.T) {
+	externalID := "14771"
+	providerID := "opencode"
+	id := uuid.New()
+
+	t.Run("should return true for matching external identity", func(t *testing.T) {
+		a := &Project{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		b := &Project{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		assert.True(t, a.Same(b))
+	})
+
+	t.Run("should not panic when other has no external identity", func(t *testing.T) {
+		a := &Project{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		b := &Project{Model: Model{ID: uuid.New()}}
+		assert.NotPanics(t, func() { a.Same(b) })
+		assert.False(t, a.Same(b))
+	})
+
+	t.Run("should fall back to id when neither has an external identity", func(t *testing.T) {
+		a := &Project{Model: Model{ID: id}}
+		b := &Project{Model: Model{ID: id}}
+		assert.True(t, a.Same(b))
+	})
+
+	t.Run("should not panic when other is nil", func(t *testing.T) {
+		a := &Project{ExternalEntityID: &externalID, ExternalEntityProviderID: &providerID}
+		assert.NotPanics(t, func() { a.Same(nil) })
+		assert.False(t, a.Same(nil))
+	})
+}

--- a/database/repositories/slugs_test.go
+++ b/database/repositories/slugs_test.go
@@ -80,4 +80,46 @@ func TestInjectUniqueSlugs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "alpha-1", projects[0].Slug)
 	})
+
+	t.Run("should assign new slug when incoming asset has external entity but existing does not", func(t *testing.T) {
+		externalID := "12471"
+		providerID := "opencode"
+		existing := []*models.Asset{
+			{Slug: "frontend", Model: models.Model{ID: uuid.New()}},
+		}
+		assets := []*models.Asset{
+			{
+				Slug:                     "frontend",
+				ExternalEntityID:         &externalID,
+				ExternalEntityProviderID: &providerID,
+			},
+		}
+
+		err := injectUniqueSlugs(existing, assets)
+		assert.NoError(t, err)
+		assert.Equal(t, "frontend-1", assets[0].Slug)
+	})
+
+	t.Run("should keep slug when incoming and existing assets share the same external entity", func(t *testing.T) {
+		externalID := "12471"
+		providerID := "opencode"
+		existing := []*models.Asset{
+			{
+				Slug:                     "frontend",
+				ExternalEntityID:         &externalID,
+				ExternalEntityProviderID: &providerID,
+			},
+		}
+		assets := []*models.Asset{
+			{
+				Slug:                     "frontend",
+				ExternalEntityID:         &externalID,
+				ExternalEntityProviderID: &providerID,
+			},
+		}
+
+		err := injectUniqueSlugs(existing, assets)
+		assert.NoError(t, err)
+		assert.Equal(t, "frontend", assets[0].Slug)
+	})
 }


### PR DESCRIPTION
## Summary
- Fixes a panic in `Asset.Same` (and the same bug in `Project.Same`) during external-entity-provider sync when an incoming asset with external IDs shares a slug with an existing local asset that has none.
- `Same` now nil-checks both sides before comparing external identity, falling back to database UUID when either side is incomplete.
- Adds unit tests that reproduce the crash from #2870 (`injectUniqueSlugs` during asset upsert).

Fixes #2870

## Test plan
- [ ] `go test ./database/models/ ./database/repositories/ -count=1`
- [ ] Trigger an external entity provider sync where a GitLab/OpenCode asset slug collides with an existing local asset in the same project
- [ ] Confirm the process no longer panics and the incoming asset gets a suffixed slug (e.g. `frontend-1`)