### PR TITLE
feat: sign webhook payloads with HMAC

### DIFF
--- a/services/webhook_service.go
+++ b/services/webhook_service.go
@@ -100,7 +100,7 @@ func (c *webhookClient) CreateRequest(ctx context.Context, method, url string, b
 		if err != nil {
 			return nil, err
 		}
-		if c.Secret != nil {
+		if c.Secret != nil && *c.Secret != "" {
 			req.Header.Set("X-Webhook-Secret", *c.Secret)
 		}
 		if signature != "" {

--- a/services/webhook_service.go
+++ b/services/webhook_service.go
@@ -6,6 +6,9 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -70,6 +73,13 @@ func (c *webhookClient) CreateRequest(ctx context.Context, method, url string, b
 		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
 
+	var signature string
+	if c.Secret != nil && *c.Secret != "" {
+		mac := hmac.New(sha256.New, []byte(*c.Secret))
+		_, _ = mac.Write(bodyBytes)
+		signature = "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()
 
@@ -92,6 +102,9 @@ func (c *webhookClient) CreateRequest(ctx context.Context, method, url string, b
 		}
 		if c.Secret != nil {
 			req.Header.Set("X-Webhook-Secret", *c.Secret)
+		}
+		if signature != "" {
+			req.Header.Set("X-Hub-Signature-256", signature)
 		}
 		req.Header.Set("Content-Type", "application/json")
 

--- a/services/webhook_service.go
+++ b/services/webhook_service.go
@@ -73,8 +73,9 @@ func (c *webhookClient) CreateRequest(ctx context.Context, method, url string, b
 		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
 
+	hasSecret := c.Secret != nil && *c.Secret != ""
 	var signature string
-	if c.Secret != nil && *c.Secret != "" {
+	if hasSecret {
 		mac := hmac.New(sha256.New, []byte(*c.Secret))
 		_, _ = mac.Write(bodyBytes)
 		signature = "sha256=" + hex.EncodeToString(mac.Sum(nil))
@@ -100,7 +101,7 @@ func (c *webhookClient) CreateRequest(ctx context.Context, method, url string, b
 		if err != nil {
 			return nil, err
 		}
-		if c.Secret != nil && *c.Secret != "" {
+		if hasSecret {
 			req.Header.Set("X-Webhook-Secret", *c.Secret)
 		}
 		if signature != "" {

--- a/services/webhook_service_test.go
+++ b/services/webhook_service_test.go
@@ -5,6 +5,10 @@ package services
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,6 +23,75 @@ func newTestWebhookService(url string) *webhookClient {
 	webhookClient := NewWebhookService(url, nil)
 	webhookClient.retryDelays = []time.Duration{0, 0, 0}
 	return webhookClient
+}
+
+func TestWebhookClient_CreateRequest_HMACSignature(t *testing.T) {
+	const secret = "test-webhook-secret"
+	body := `{"event":"dependencyVulnerabilities","severity":"high"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write(receivedBody)
+		expectedSignature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+		assert.Equal(t, body, string(receivedBody))
+		assert.Equal(t, expectedSignature, r.Header.Get("X-Hub-Signature-256"))
+		assert.Equal(t, secret, r.Header.Get("X-Webhook-Secret"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	secretValue := secret
+	client := NewWebhookService(server.URL, &secretValue)
+	client.retryDelays = []time.Duration{0, 0, 0}
+
+	resp, err := client.CreateRequest(context.Background(), http.MethodPost, server.URL, strings.NewReader(body))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestWebhookClient_CreateRequest_DoesNotSignWithoutSecret(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("X-Hub-Signature-256"))
+		assert.Empty(t, r.Header.Get("X-Webhook-Secret"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestWebhookService(server.URL)
+	resp, err := client.CreateRequest(context.Background(), http.MethodPost, server.URL, strings.NewReader(`{"test":"data"}`))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+}
+
+func TestWebhookClient_CreateRequest_ReusesSignatureAcrossRetries(t *testing.T) {
+	const secret = "test-webhook-secret"
+	body := `{"event":"test"}`
+	var signatures []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		signatures = append(signatures, r.Header.Get("X-Hub-Signature-256"))
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	secretValue := secret
+	client := NewWebhookService(server.URL, &secretValue)
+	client.retryDelays = []time.Duration{0, 0, 0}
+	resp, err := client.CreateRequest(context.Background(), http.MethodPost, server.URL, strings.NewReader(body))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+
+	require.Len(t, signatures, 3)
+	assert.Equal(t, signatures[0], signatures[1])
+	assert.Equal(t, signatures[1], signatures[2])
 }
 
 func TestWebhookClient_CreateRequest_RetryLogic(t *testing.T) {

--- a/services/webhook_service_test.go
+++ b/services/webhook_service_test.go
@@ -56,18 +56,32 @@ func TestWebhookClient_CreateRequest_HMACSignature(t *testing.T) {
 }
 
 func TestWebhookClient_CreateRequest_DoesNotSignWithoutSecret(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Empty(t, r.Header.Get("X-Hub-Signature-256"))
-		assert.Empty(t, r.Header.Get("X-Webhook-Secret"))
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	emptySecret := ""
+	cases := []struct {
+		name   string
+		secret *string
+	}{
+		{name: "nil secret", secret: nil},
+		{name: "empty secret", secret: &emptySecret},
+	}
 
-	client := newTestWebhookService(server.URL)
-	resp, err := client.CreateRequest(context.Background(), http.MethodPost, server.URL, strings.NewReader(`{"test":"data"}`))
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	defer resp.Body.Close()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Empty(t, r.Header.Get("X-Hub-Signature-256"))
+				assert.Empty(t, r.Header.Get("X-Webhook-Secret"))
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			client := NewWebhookService(server.URL, tc.secret)
+			client.retryDelays = []time.Duration{0, 0, 0}
+			resp, err := client.CreateRequest(context.Background(), http.MethodPost, server.URL, strings.NewReader(`{"test":"data"}`))
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			defer resp.Body.Close()
+		})
+	}
 }
 
 func TestWebhookClient_CreateRequest_ReusesSignatureAcrossRetries(t *testing.T) {


### PR DESCRIPTION
## Summary

  Fixes #2206
  Add HMAC-SHA256 signing for outgoing webhook payloads.

  ## Changes

  - Generate an HMAC-SHA256 signature from the exact JSON request body using the configured webhook secret.
  - Send the signature using the X-Hub-Signature-256 header.
  - Preserve the existing X-Webhook-Secret header for backward compatibility.
  - Skip the HMAC header when no secret is configured.
  - Reuse the same signature across webhook retries.
  - Add tests for signature generation, missing secrets, legacy header support, and retry consistency.

  ## Testing

  go test -v ./services -run 'TestWebhookClient_CreateRequest' -count=1

  All webhook tests pass.