### PR TITLE
fix: use CycloneDX 1.6 for sample SBOM

### DIFF
--- a/services/webhook_service.go
+++ b/services/webhook_service.go
@@ -209,7 +209,7 @@ func testPayload(payloadType TestPayloadType) (any, WebhookType) {
 func createSampleSBOM() cdx.BOM {
 	return cdx.BOM{
 		BOMFormat:    "CycloneDX",
-		SpecVersion:  cdx.SpecVersion1_4,
+		SpecVersion:  cdx.SpecVersion1_6,
 		SerialNumber: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
 		Version:      1,
 		Metadata: &cdx.Metadata{

--- a/services/webhook_service_test.go
+++ b/services/webhook_service_test.go
@@ -195,3 +195,7 @@ func TestWebhookClient_CreateRequest_RetryLogic(t *testing.T) {
 		assert.Equal(t, 3, attemptCount, "Should retry on 429")
 	})
 }
+
+func TestCreateSampleSBOMUsesCycloneDX16(t *testing.T) {
+	assert.Equal(t, "1.6", createSampleSBOM().SpecVersion.String())
+}


### PR DESCRIPTION
## Summary

- emit sample SBOM webhook payloads using CycloneDX 1.6
- add focused regression coverage for the sample payload's spec version

## Validation

- `go test ./services -count=1`
- all non-Docker packages from the repository test command passed
- `golangci-lint run --new-from-rev=upstream/main` (0 issues)
- `go vet ./services`
- `gofmt` and `git diff --check`

The root integration-test package requires Docker/Testcontainers, which is not available in the local environment. Its Docker-provider failure reproduces unchanged on pristine `upstream/main`.

Closes #2898
