### PR TITLE
collect recent commit hashes to find nearest ancestor branch

### DIFF
--- a/cmd/devguard-scanner/config/config.go
+++ b/cmd/devguard-scanner/config/config.go
@@ -63,14 +63,15 @@ type baseConfig struct {
 	Password string `json:"password" mapstructure:"password"`
 	Registry string `json:"registry" mapstructure:"registry"`
 
-	ScannerID     string `json:"scannerId" mapstructure:"scannerID"`
-	Ref           string `json:"ref" mapstructure:"ref"`
-	DefaultBranch string `json:"defaultRef" mapstructure:"defaultRef"`
-	IsTag         bool   `json:"isTag" mapstructure:"isTag"`
-	ArtifactName  string `json:"artifactName" mapstructure:"artifactName"`
-	Origin        string `json:"origin" mapstructure:"origin"`
-	OutputPath    string `json:"outputPath" mapstructure:"outputPath"`
-	Format        string `json:"format" mapstructure:"format"`
+	ScannerID          string `json:"scannerId" mapstructure:"scannerID"`
+	Ref                string `json:"ref" mapstructure:"ref"`
+	RecentCommitHashes []string
+	DefaultBranch      string `json:"defaultRef" mapstructure:"defaultRef"`
+	IsTag              bool   `json:"isTag" mapstructure:"isTag"`
+	ArtifactName       string `json:"artifactName" mapstructure:"artifactName"`
+	Origin             string `json:"origin" mapstructure:"origin"`
+	OutputPath         string `json:"outputPath" mapstructure:"outputPath"`
+	Format             string `json:"format" mapstructure:"format"`
 
 	Timeout                    int  `json:"timeout" mapstructure:"timeout"`
 	IgnoreExternalReferences   bool `json:"ignoreExternalReferences" mapstructure:"ignoreExternalReferences"`
@@ -158,6 +159,13 @@ func ParseBaseConfig(runningCMD string) {
 			}
 		}
 	}
+
+	hashes, err := utils.GitLister.GetRecentCommitHashes(RuntimeBaseConfig.Path)
+	if err != nil {
+		slog.Debug("could not get recent commit hashes - the api will fall back to the default branch", "err", err)
+		hashes = nil
+	}
+	RuntimeBaseConfig.RecentCommitHashes = hashes
 
 	if RuntimeBaseConfig.AssetName != "" {
 		// normalize the asset name. We allow two different formats.
@@ -263,6 +271,10 @@ func SetXAssetHeaders(req *http.Request) {
 
 	if RuntimeBaseConfig.DefaultBranch != "" {
 		req.Header.Set("X-Asset-Default-Branch", RuntimeBaseConfig.DefaultBranch)
+	}
+
+	if len(RuntimeBaseConfig.RecentCommitHashes) > 0 {
+		req.Header.Set("X-Recent-Commit-Hashes", strings.Join(RuntimeBaseConfig.RecentCommitHashes, ","))
 	}
 }
 

--- a/controllers/asset_version_controller.go
+++ b/controllers/asset_version_controller.go
@@ -109,7 +109,7 @@ func (a *AssetVersionController) Create(ctx shared.Context) error {
 		defaultBranch = &body.Name
 	}
 
-	assetVersion, err := a.assetVersionRepository.FindOrCreate(ctx.Request().Context(), nil, body.Name, asset.ID, body.Tag, defaultBranch)
+	assetVersion, err := a.assetVersionRepository.FindOrCreate(ctx.Request().Context(), nil, body.Name, asset.ID, body.Tag, defaultBranch, nil)
 	if err != nil {
 		return err
 	}

--- a/controllers/intoto_controller.go
+++ b/controllers/intoto_controller.go
@@ -164,7 +164,8 @@ func (a *InToToController) Create(ctx shared.Context) error {
 	if defaultBranch == "" {
 		defaultBranch = "main"
 	}
-	assetVersion, err := a.assetVersionRepository.FindOrCreate(ctx.Request().Context(), nil, assetVersionName, asset.ID, tag == "1", utils.EmptyThenNil(defaultBranch))
+	recentCommitHashes := utils.ParseRecentCommitHashes(ctx.Request().Header.Get("X-Recent-Commit-Hashes"))
+	assetVersion, err := a.assetVersionRepository.FindOrCreate(ctx.Request().Context(), nil, assetVersionName, asset.ID, tag == "1", utils.EmptyThenNil(defaultBranch), recentCommitHashes)
 	if err != nil {
 		return err
 	}

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -670,7 +670,7 @@ func (projectController *ProjectController) HandleExternalSubprojectRequest(ctx 
 		return echo.NewHTTPError(500, fmt.Sprintf("could not create asset: %s", err.Error())).WithInternal(err)
 	}
 
-	assetVersion, err := projectController.assetVersionRepository.FindOrCreate(ctx.Request().Context(), nil, probe.AssetVersionName, asset.ID, false, nil)
+	assetVersion, err := projectController.assetVersionRepository.FindOrCreate(ctx.Request().Context(), nil, probe.AssetVersionName, asset.ID, false, nil, nil)
 	if err != nil {
 		return echo.NewHTTPError(500, fmt.Sprintf("could not create asset version: %s", err.Error())).WithInternal(err)
 	}

--- a/controllers/scan_controller.go
+++ b/controllers/scan_controller.go
@@ -215,6 +215,7 @@ func (s *ScanController) DependencyVulnScan(c shared.Context, bom *cdx.BOM) (ope
 		slog.Warn("no X-Asset-Ref header found. Using main as ref name")
 		assetVersionName = "main"
 	}
+	recentCommitHashes := utils.ParseRecentCommitHashes(c.Request().Header.Get("X-Recent-Commit-Hashes"))
 	artifactName := c.Request().Header.Get("X-Artifact-Name")
 	origin := c.Request().Header.Get("X-Origin")
 
@@ -249,7 +250,7 @@ func (s *ScanController) DependencyVulnScan(c shared.Context, bom *cdx.BOM) (ope
 		findOrCreateTx = earlyTx
 	}
 
-	assetVersion, err = s.assetVersionRepository.FindOrCreate(scanCtx, findOrCreateTx, assetVersionName, asset.ID, tag == "1", utils.EmptyThenNil(defaultBranch))
+	assetVersion, err = s.assetVersionRepository.FindOrCreate(scanCtx, findOrCreateTx, assetVersionName, asset.ID, tag == "1", utils.EmptyThenNil(defaultBranch), recentCommitHashes)
 	if err != nil {
 		slog.Error("could not find or create asset version", "err", err)
 		span.RecordError(err)
@@ -390,6 +391,7 @@ func (s *ScanController) DependencyVulnScan(c shared.Context, bom *cdx.BOM) (ope
 // @Param X-Asset-Ref header string false "Asset version name"
 // @Param X-Tag header string false "Tag flag"
 // @Param X-Asset-Default-Branch header string false "Default branch"
+// @Param X-Recent-Commit-Hashes header string false "Comma separated commit hashes of the scanned ref, newest first"
 // @Param X-Scanner header string true "Scanner ID"
 // @Success 200 {object} dtos.FirstPartyScanResponse
 // @Router /sarif-scan [post]
@@ -425,6 +427,7 @@ func (s *ScanController) FirstPartyVulnScan(ctx shared.Context) error {
 		assetVersionName = "main"
 		defaultBranch = "main"
 	}
+	recentCommitHashes := utils.ParseRecentCommitHashes(ctx.Request().Header.Get("X-Recent-Commit-Hashes"))
 
 	span.SetAttributes(
 		attribute.String("org.slug", org.Slug),
@@ -433,7 +436,7 @@ func (s *ScanController) FirstPartyVulnScan(ctx shared.Context) error {
 		attribute.String("assetVersion.name", assetVersionName),
 	)
 
-	assetVersion, err := s.assetVersionRepository.FindOrCreate(reqCtx, nil, assetVersionName, asset.ID, tag == "1", utils.EmptyThenNil(defaultBranch))
+	assetVersion, err := s.assetVersionRepository.FindOrCreate(reqCtx, nil, assetVersionName, asset.ID, tag == "1", utils.EmptyThenNil(defaultBranch), recentCommitHashes)
 	if err != nil {
 		slog.Error("could not find or create asset version", "err", err)
 		span.RecordError(err)
@@ -500,6 +503,7 @@ func (s *ScanController) FirstPartyVulnScan(ctx shared.Context) error {
 // @Param X-Artifact-Name header string false "Artifact name"
 // @Param X-Tag header string false "Tag flag"
 // @Param X-Asset-Default-Branch header string false "Default branch"
+// @Param X-Recent-Commit-Hashes header string false "Comma separated commit hashes of the scanned ref, newest first"
 // @Param X-Origin header string false "Origin"
 // @Param X-Scanner header string false "Scanner ID"
 // @Success 200 {object} dtos.ScanResponse
@@ -842,8 +846,9 @@ func (s *ScanController) ScanSarifFile(c shared.Context) error {
 		assetVersionName = "main"
 		defaultBranch = "main"
 	}
+	recentCommitHashes := utils.ParseRecentCommitHashes(c.Request().Header.Get("X-Recent-Commit-Hashes"))
 
-	assetVersion, err := s.assetVersionRepository.FindOrCreate(c.Request().Context(), nil, assetVersionName, asset.ID, tag == "1", utils.EmptyThenNil(defaultBranch))
+	assetVersion, err := s.assetVersionRepository.FindOrCreate(c.Request().Context(), nil, assetVersionName, asset.ID, tag == "1", utils.EmptyThenNil(defaultBranch), recentCommitHashes)
 	if err != nil {
 		slog.Error("could not find or create asset version", "err", err)
 		span.RecordError(err)

--- a/database/migrations/20260818103000_add_recent_commit_hashes_to_asset_versions.up.sql
+++ b/database/migrations/20260818103000_add_recent_commit_hashes_to_asset_versions.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.asset_versions
+    ADD COLUMN recent_commit_hashes JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_asset_versions_recent_commit_hashes
+    ON public.asset_versions USING GIN ((recent_commit_hashes -> 'recentCommits'));

--- a/database/models/asset_version_model.go
+++ b/database/models/asset_version_model.go
@@ -18,6 +18,8 @@ type ScannerInformation struct {
 	LastScan *time.Time `json:"lastScan,omitempty"`
 }
 
+const RecentCommitsKey = "recentCommits"
+
 type AssetVersion struct {
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
@@ -26,13 +28,14 @@ type AssetVersion struct {
 	AssetID uuid.UUID `json:"assetId" gorm:"primarykey;not null;type:uuid;"`
 	Asset   Asset     `json:"asset" gorm:"foreignKey:AssetID;references:ID; constraint:OnDelete:CASCADE;"`
 
-	DefaultBranch   bool                  `json:"defaultBranch" gorm:"default:false;"`
-	Slug            string                `json:"slug" gorm:"type:text;not null;type:text;"`
-	DependencyVulns []DependencyVuln      `json:"dependencyVulns" gorm:"foreignKey:AssetVersionName,AssetID;references:Name,AssetID;constraint:OnDelete:CASCADE;"`
-	Artifacts       []Artifact            `json:"artifacts" gorm:"foreignKey:AssetVersionName,AssetID;references:Name,AssetID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	Type            AssetVersionType      `json:"type" gorm:"type:text;not null;"`
-	Components      []ComponentDependency `json:"components" gorm:"foreignKey:AssetVersionName,AssetID;references:Name,AssetID;constraint:OnDelete:CASCADE;"`
-	SupplyChains    []SupplyChain         `json:"supplyChains" gorm:"foreignKey:AssetVersionName,AssetID;references:Name,AssetID;constraint:OnDelete:CASCADE;"`
+	DefaultBranch      bool                  `json:"defaultBranch" gorm:"default:false;"`
+	Slug               string                `json:"slug" gorm:"type:text;not null;type:text;"`
+	DependencyVulns    []DependencyVuln      `json:"dependencyVulns" gorm:"foreignKey:AssetVersionName,AssetID;references:Name,AssetID;constraint:OnDelete:CASCADE;"`
+	Artifacts          []Artifact            `json:"artifacts" gorm:"foreignKey:AssetVersionName,AssetID;references:Name,AssetID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Type               AssetVersionType      `json:"type" gorm:"type:text;not null;"`
+	Components         []ComponentDependency `json:"components" gorm:"foreignKey:AssetVersionName,AssetID;references:Name,AssetID;constraint:OnDelete:CASCADE;"`
+	SupplyChains       []SupplyChain         `json:"supplyChains" gorm:"foreignKey:AssetVersionName,AssetID;references:Name,AssetID;constraint:OnDelete:CASCADE;"`
+	RecentCommitHashes databasetypes.JSONB   `json:"recentCommitHashes" gorm:"type:jsonb;"`
 
 	SigningPubKey  *string             `json:"signingPubKey" gorm:"type:text;"`
 	Metadata       databasetypes.JSONB `json:"metadata" gorm:"type:jsonb"`

--- a/database/repositories/asset_version_repository.go
+++ b/database/repositories/asset_version_repository.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gosimple/slug"
 	"github.com/l3montree-dev/devguard/database/models"
+	databasetypes "github.com/l3montree-dev/devguard/database/types"
 	"github.com/l3montree-dev/devguard/shared"
 	"github.com/l3montree-dev/devguard/utils"
 	"gorm.io/gorm"
@@ -108,7 +109,7 @@ func (repository *assetVersionRepository) findByAssetVersionNameAndAssetID(ctx c
 	return app, nil
 }
 
-func (repository *assetVersionRepository) FindOrCreate(ctx context.Context, tx *gorm.DB, assetVersionName string, assetID uuid.UUID, isTag bool, defaultBranchName *string) (models.AssetVersion, error) {
+func (repository *assetVersionRepository) FindOrCreate(ctx context.Context, tx *gorm.DB, assetVersionName string, assetID uuid.UUID, isTag bool, defaultBranchName *string, recentCommitHashes []string) (models.AssetVersion, error) {
 	var assetVersion models.AssetVersion
 	assetVersion, err := repository.findByAssetVersionNameAndAssetID(ctx, tx, assetVersionName, assetID)
 	if err != nil {
@@ -125,6 +126,9 @@ func (repository *assetVersionRepository) FindOrCreate(ctx context.Context, tx *
 			Slug:    slug.Make(assetVersionName),
 			Type:    assetVersionType,
 		}
+		if len(recentCommitHashes) > 0 {
+			assetVersion.RecentCommitHashes = databasetypes.JSONB{models.RecentCommitsKey: recentCommitHashes}
+		}
 
 		if assetVersion.Name == "" || assetVersion.Slug == "" {
 			return assetVersion, fmt.Errorf("assetVersions with an empty name or an empty slug are not allowed")
@@ -133,9 +137,20 @@ func (repository *assetVersionRepository) FindOrCreate(ctx context.Context, tx *
 		err := repository.GetDB(ctx, tx).Create(&assetVersion).Error
 		//Check if the given assetVersion already exists if thats the case don't want to add repository new entry to the db but instead update the existing one
 		if err != nil && strings.Contains(err.Error(), "duplicate key value violates") {
-			repository.GetDB(ctx, tx).Unscoped().Model(&assetVersion).Where("name", assetVersionName)
+			repository.GetDB(ctx, tx).Unscoped().Model(&assetVersion).Where("name = ?", assetVersionName).Updates(assetVersion)
 		} else if err != nil {
 			return models.AssetVersion{}, err
+		}
+	}
+
+	if len(recentCommitHashes) > 0 {
+		hashes := databasetypes.JSONB{models.RecentCommitsKey: recentCommitHashes}
+		if err := repository.GetDB(ctx, tx).Model(&models.AssetVersion{}).
+			Where("name = ? AND asset_id = ?", assetVersion.Name, assetVersion.AssetID).
+			Update("recent_commit_hashes", hashes).Error; err != nil {
+			slog.Error("could not update recent commit hashes", "err", err, "assetVersion", assetVersion.Name, "assetID", assetID)
+		} else {
+			assetVersion.RecentCommitHashes = hashes
 		}
 	}
 
@@ -150,6 +165,29 @@ func (repository *assetVersionRepository) FindOrCreate(ctx context.Context, tx *
 	}
 
 	return assetVersion, nil
+}
+
+func (repository *assetVersionRepository) GetNearestAncestorAssetVersion(ctx context.Context, tx *gorm.DB, assetVersionName string, assetID uuid.UUID) (*models.AssetVersion, error) {
+	var nearest models.AssetVersion
+	err := repository.GetDB(ctx, tx).Raw(`
+SELECT candidate.*
+FROM asset_versions target
+CROSS JOIN LATERAL jsonb_array_elements_text(target.recent_commit_hashes -> ?) WITH ORDINALITY AS t(hash, ord)
+JOIN asset_versions candidate
+  ON candidate.asset_id = target.asset_id
+ AND candidate.name <> target.name
+ AND candidate.recent_commit_hashes -> ? @> to_jsonb(t.hash)
+WHERE target.name = ? AND target.asset_id = ?
+GROUP BY candidate.name, candidate.asset_id
+ORDER BY MIN(t.ord) ASC, candidate.default_branch DESC, candidate.last_accessed_at DESC
+LIMIT 1`,
+		models.RecentCommitsKey, models.RecentCommitsKey, assetVersionName, assetID,
+	).First(&nearest).Error
+
+	if err != nil {
+		return nil, err
+	}
+	return &nearest, nil
 }
 
 func (repository *assetVersionRepository) UpdateAssetDefaultBranch(ctx context.Context, tx *gorm.DB, assetID uuid.UUID, defaultBranch string) error {

--- a/shared/common_interfaces.go
+++ b/shared/common_interfaces.go
@@ -501,9 +501,10 @@ type AssetVersionRepository interface {
 	GetAssetVersionsByAssetIDWithArtifacts(ctx context.Context, tx DB, assetID uuid.UUID) ([]models.AssetVersion, error)
 	GetDefaultAssetVersionsByProjectID(ctx context.Context, tx DB, projectID uuid.UUID) ([]models.AssetVersion, error)
 	GetDefaultAssetVersionsByProjectIDs(ctx context.Context, tx DB, projectIDs []uuid.UUID) ([]models.AssetVersion, error)
-	FindOrCreate(ctx context.Context, tx DB, assetVersionName string, assetID uuid.UUID, tag bool, defaultBranchName *string) (models.AssetVersion, error)
+	FindOrCreate(ctx context.Context, tx DB, assetVersionName string, assetID uuid.UUID, tag bool, defaultBranchName *string, recentCommitHashes []string) (models.AssetVersion, error)
 	ReadBySlug(ctx context.Context, tx DB, assetID uuid.UUID, slug string) (models.AssetVersion, error)
 	GetDefaultAssetVersion(ctx context.Context, tx DB, assetID uuid.UUID) (models.AssetVersion, error)
+	GetNearestAncestorAssetVersion(ctx context.Context, tx DB, assetVersionName string, assetID uuid.UUID) (*models.AssetVersion, error)
 	GetAllTagsAndDefaultBranchForAsset(ctx context.Context, tx DB, assetID uuid.UUID) ([]models.AssetVersion, error)
 	UpdateAssetDefaultBranch(ctx context.Context, tx DB, assetID uuid.UUID, defaultBranch string) error
 	DeleteOldAssetVersions(ctx context.Context, tx DB, day int) (int64, error)

--- a/utils/git.go
+++ b/utils/git.go
@@ -89,6 +89,7 @@ type gitLister interface {
 	GitCommitCount(path string, tag *string) (int, error)
 	GetBranchName(path string) (string, error)
 	GetDefaultBranchName(path string) (string, error)
+	GetRecentCommitHashes(path string) ([]string, error)
 }
 
 type commandLineGitLister struct {
@@ -131,6 +132,58 @@ func (g commandLineGitLister) GetBranchName(path string) (string, error) {
 	}
 
 	return strings.TrimSpace(out.String()), nil
+}
+
+func (g commandLineGitLister) GetRecentCommitHashes(path string) ([]string, error) {
+	const ShortCommitHashLength = 7
+	const limit = 250
+
+	cmd := exec.Command("git", "log", "-n", strconv.Itoa(limit), "--format=%H") // nolint: gosec
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	cmd.Dir = getDirFromPath(path)
+	if err := cmd.Run(); err != nil {
+		slog.Debug("could not get recent commit hashes", "err", err, "path", getDirFromPath(path), "msg", errOut.String())
+		return nil, err
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	hashes := make([]string, 0, len(lines))
+	for _, line := range lines {
+		hash := strings.TrimSpace(line)
+		if hash == "" {
+			continue
+		}
+		if len(hash) > ShortCommitHashLength {
+			hash = hash[:ShortCommitHashLength]
+		}
+		hashes = append(hashes, hash)
+	}
+
+	return hashes, nil
+}
+
+func ParseRecentCommitHashes(hashesStr string) []string {
+	if hashesStr == "" {
+		return nil
+	}
+
+	parts := strings.Split(hashesStr, ",")
+	hashes := make([]string, 0, len(parts))
+	for _, part := range parts {
+		hash := strings.TrimSpace(part)
+		if hash == "" {
+			continue
+		}
+		hashes = append(hashes, hash)
+	}
+
+	if len(hashes) == 0 {
+		return nil
+	}
+	return hashes
 }
 
 func (g commandLineGitLister) MarkAllPathsAsSafe() error {


### PR DESCRIPTION
Closes #2796

### Done
- Scanner CLI collects recent commit hashes and sends them via the `X-Recent-Commit-Hashes` header.
- API stores the hashes in `AssetVersion.RecentCommitHashes` (jsonb).
- New repository method `GetNearestAncestorAssetVersion` finds the nearest ancestor AssetVersion via SQL based on shared commits.
- Added migration for the new column.

### Open
- `GetNearestAncestorAssetVersion` isn't wired up yet: `scan_service.go` still diffs against all other AssetVersions instead of just the real ancestor.
- Fallback behavior when no common commit is found is not yet defined.
- Tests for the new ancestor lookup are still missing.
