### PR TITLE
fix(github): page installation repositories from 1, and stop when a page is empty

### DIFF
--- a/integrations/githubint/github_client.go
+++ b/integrations/githubint/github_client.go
@@ -62,27 +62,35 @@ func newGithubBatchClient(appInstallations []models.GithubAppInstallation) (*git
 	}, nil
 }
 
+const installationReposPerPage = 100
+
 func fetchAllRepos(ctx context.Context, client githubClient) ([]*github.Repository, error) {
-	result, _, err := client.Apps.ListRepos(ctx, &github.ListOptions{
-		Page:    1,
-		PerPage: 100,
-	})
+	var repos []*github.Repository
 
-	if err != nil {
-		return nil, err
-	}
-
-	repos := result.Repositories
-	// check if there is more to fetch
-	for len(repos) < *result.TotalCount {
-		result, _, err = client.Apps.ListRepos(ctx, &github.ListOptions{
-			Page:    len(repos) / 100,
-			PerPage: 100,
+	// GitHub pagination is 1-indexed, so the page to ask for is simply the one
+	// after the page we just read.
+	for page := 1; ; page++ {
+		result, _, err := client.Apps.ListRepos(ctx, &github.ListOptions{
+			Page:    page,
+			PerPage: installationReposPerPage,
 		})
 		if err != nil {
 			return nil, err
 		}
+
+		// A page that yields nothing means there is nothing left to fetch.
+		// Without this, an installation whose total_count is larger than the
+		// number of repositories it actually hands out keeps this loop - and the
+		// request that triggered it - running forever.
+		if len(result.Repositories) == 0 {
+			break
+		}
+
 		repos = append(repos, result.Repositories...)
+
+		if result.TotalCount == nil || len(repos) >= *result.TotalCount {
+			break
+		}
 	}
 
 	return repos, nil

--- a/integrations/githubint/github_client_test.go
+++ b/integrations/githubint/github_client_test.go
@@ -1,0 +1,191 @@
+// Copyright (C) 2024 Tim Bastin, l3montree GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package githubint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v62/github"
+	"github.com/stretchr/testify/assert"
+)
+
+// installationReposServer serves GET /installation/repositories with `total`
+// repositories paginated at `perPage`, and records which page numbers were
+// requested. Repository full names are "acme/repo-<n>" with n starting at 1, so
+// a caller can tell exactly which repositories it did and did not receive.
+type installationReposServer struct {
+	mu             sync.Mutex
+	requestedPages []int
+}
+
+func (s *installationReposServer) pages() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]int(nil), s.requestedPages...)
+}
+
+func newInstallationReposClient(t *testing.T, total, perPage int) (githubClient, *installationReposServer) {
+	t.Helper()
+
+	recorder := &installationReposServer{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil {
+			page = 1
+		}
+
+		recorder.mu.Lock()
+		recorder.requestedPages = append(recorder.requestedPages, page)
+		// Guard the test itself against the infinite paging loop this test
+		// exists to detect - fail loudly instead of hanging the suite.
+		tooManyRequests := len(recorder.requestedPages) > 50
+		recorder.mu.Unlock()
+		if tooManyRequests {
+			t.Errorf("fetchAllRepos kept paging: %d requests for %d repositories", 50, total)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		repos := []*github.Repository{}
+		// GitHub pagination is 1-indexed.
+		start := (page - 1) * perPage
+		for i := start; i < start+perPage && i < total; i++ {
+			name := fmt.Sprintf("acme/repo-%d", i+1)
+			repos = append(repos, &github.Repository{FullName: github.String(name)})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		//nolint:errcheck // test server
+		json.NewEncoder(w).Encode(struct {
+			TotalCount   int                  `json:"total_count"`
+			Repositories []*github.Repository `json:"repositories"`
+		}{TotalCount: total, Repositories: repos})
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/api/v3/")
+	assert.NoError(t, err)
+
+	client := github.NewClient(server.Client())
+	client.BaseURL = baseURL
+
+	return githubClient{Client: client, githubAppInstallationID: 1}, recorder
+}
+
+func fullNames(repos []*github.Repository) []string {
+	names := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		names = append(names, repo.GetFullName())
+	}
+	return names
+}
+
+func TestFetchAllRepos(t *testing.T) {
+	t.Run("it should return every repository exactly once when they fit on a single page", func(t *testing.T) {
+		client, _ := newInstallationReposClient(t, 3, 100)
+
+		repos, err := fetchAllRepos(context.Background(), client)
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"acme/repo-1", "acme/repo-2", "acme/repo-3"}, fullNames(repos))
+	})
+
+	t.Run("it should return every repository exactly once when they span multiple pages", func(t *testing.T) {
+		// 250 repositories at 100 per page is three pages: 100, 100, 50.
+		client, recorder := newInstallationReposClient(t, 250, 100)
+
+		repos, err := fetchAllRepos(context.Background(), client)
+
+		assert.NoError(t, err)
+		assert.Len(t, repos, 250, "expected all 250 repositories, no duplicates and none dropped")
+		assert.Equal(t, []int{1, 2, 3}, recorder.pages(), "each page should be fetched exactly once")
+
+		// Every repository is present exactly once - in particular the tail,
+		// which is the page an off-by-one page index silently drops.
+		seen := map[string]int{}
+		for _, name := range fullNames(repos) {
+			seen[name]++
+		}
+		assert.Len(t, seen, 250)
+		for i := 1; i <= 250; i++ {
+			name := fmt.Sprintf("acme/repo-%d", i)
+			assert.Equal(t, 1, seen[name], "expected %s exactly once, got %d", name, seen[name])
+		}
+	})
+
+	t.Run("it should stop when a page comes back empty even if total_count disagrees", func(t *testing.T) {
+		// total_count is 500 but the server only ever has 120 repositories to
+		// hand out, so page 3 onwards is empty. Without a no-progress guard the
+		// loop never reaches total_count and pages forever.
+		client, _ := newInstallationReposClient(t, 120, 100)
+		client.githubAppInstallationID = 2
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/v3/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+			page, err := strconv.Atoi(r.URL.Query().Get("page"))
+			if err != nil {
+				page = 1
+			}
+			repos := []*github.Repository{}
+			start := (page - 1) * 100
+			for i := start; i < start+100 && i < 120; i++ {
+				repos = append(repos, &github.Repository{FullName: github.String(fmt.Sprintf("acme/repo-%d", i+1))})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			//nolint:errcheck // test server
+			json.NewEncoder(w).Encode(struct {
+				TotalCount   int                  `json:"total_count"`
+				Repositories []*github.Repository `json:"repositories"`
+			}{TotalCount: 500, Repositories: repos})
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+		baseURL, err := url.Parse(server.URL + "/api/v3/")
+		assert.NoError(t, err)
+		inconsistent := github.NewClient(server.Client())
+		inconsistent.BaseURL = baseURL
+
+		done := make(chan struct{})
+		var repos []*github.Repository
+		var fetchErr error
+		go func() {
+			defer close(done)
+			repos, fetchErr = fetchAllRepos(context.Background(), githubClient{Client: inconsistent, githubAppInstallationID: 2})
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("fetchAllRepos did not terminate when total_count overstated the number of repositories")
+		}
+
+		assert.NoError(t, fetchErr)
+		assert.Len(t, repos, 120)
+	})
+}


### PR DESCRIPTION
`fetchAllRepos` in `integrations/githubint/github_client.go` pages the installation's repositories like this:

```go
result, _, err := client.Apps.ListRepos(ctx, &github.ListOptions{Page: 1, PerPage: 100})
repos := result.Repositories
for len(repos) < *result.TotalCount {
    result, _, err = client.Apps.ListRepos(ctx, &github.ListOptions{Page: len(repos) / 100, PerPage: 100})
    ...
}
```

GitHub's pagination is 1-indexed, so `len(repos) / 100` is the page we just read, not the next one.

### What that does

For an installation with 250 repositories (three pages of 100/100/50):

| iteration | `len(repos)` | page requested | should be |
|---|---|---|---|
| initial | 0 | 1 | 1 |
| 1 | 100 | **1** | 2 |
| 2 | 200 | **2** | 3 |
| — | 300 ≥ 250, loop ends | | |

Page 1 is fetched twice and **page 3 is never fetched**. The caller gets 300 entries for 250 repositories: 100 duplicates, and `acme/repo-201..250` missing entirely. In the UI that reads as duplicated rows in the repository picker plus repositories that cannot be connected at all — which is easy to mistake for the repository not being visible to the installation.

### And it can fail to terminate

The only exit is reaching `TotalCount`. If an installation reports more repositories than it will actually hand out, a page comes back empty while `len(repos)` is still short of `TotalCount`, the condition stays true, and the loop keeps calling the GitHub API — inside the HTTP request that triggered the listing. `*result.TotalCount` is also dereferenced without a nil check.

### The change

Walk pages with an explicit 1-indexed counter, stop as soon as a page yields no repositories, and treat a missing `total_count` as "that was the last page". Same signature, same return value, no behaviour change for installations that fit on one page.

### Verification

`integrations/githubint/github_client_test.go` drives `fetchAllRepos` against an `httptest` server that records which page numbers were requested, so **no GitHub credentials or network access are needed**. Three cases: single page, 250 repositories across three pages, and a server whose `total_count` overstates what it returns.

Against **unmodified `main`** the new tests fail exactly as described — the multi-page case reports `acme/repo-201..250` missing, and the inconsistent-`total_count` case hits the test's 10s guard without terminating. With this change all three pass in 0.01s.

I ran the full suite on `main` and on this branch and the results are identical: 31 packages `ok`, and the same 9 pre-existing failures in `database/repositories` (`TestAutoTenantScope*`) and `tests` (`TestGitleaksVulnPathThroughRealBackend`), which need a Docker/testcontainers runtime this machine does not have. `gofmt` and `go vet` are clean. `golangci-lint` reports the same 7 pre-existing `staticcheck` findings before and after, all in `github_integration.go`, which this PR does not touch; **0 findings in either file it does touch.**

### Scope

This is only the paging bug. #2572 concerns the same repository-listing path but asks for orphaned-installation feedback and deletion on top of graceful degradation — I have deliberately not touched that here, since the hotfix in d688ab5c already keeps a dead installation from breaking the healthy ones, and the remaining parts of that issue are a UI/API surface question rather than this loop. Happy to pick that up separately if it would help.

One judgement call worth flagging: I kept `PerPage: 100` as a named constant rather than making it configurable, since nothing else in the file parameterises it. Say the word if you would rather it stayed a literal.

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*