### PR TITLE
feat(oci): add tar binary to postgresql container image

### DIFF
--- a/nix/oci.nix
+++ b/nix/oci.nix
@@ -222,6 +222,7 @@ rec {
         postgresql.config
         pkgs.bash
         pkgs.coreutils
+        pkgs.gnutar
       ]
       ++ (if debug then [ pkgs.busybox ] else [ ]);
 


### PR DESCRIPTION
This PR will add the `tar` binary (using the `gnutar` nix package) to the `devguard-postgresql` container image.
The tar binary will enable the usage of the `kubectl cp` command. Taken from the command output:

```bash
$ kubectl cp --help
Copy files and directories to and from containers.

Examples:
  # !!!Important Note!!!
  # Requires that the 'tar' binary is present in your container
  # image.  If 'tar' is not present, 'kubectl cp' will fail.
[...]
```
I haven't found any docs or tests related to the OCI build details which should also be updated.
If I missed to add something, please let me know.

closes #2924 