### PR TITLE
Implemented baseURL endpoint through instance settings

### DIFF
--- a/controllers/admin_controller.go
+++ b/controllers/admin_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/l3montree-dev/devguard/integrations/gitlabint"
 	"github.com/l3montree-dev/devguard/monitoring"
 	"github.com/l3montree-dev/devguard/shared"
+	"github.com/l3montree-dev/devguard/transformer"
 	"github.com/l3montree-dev/devguard/utils"
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
@@ -384,16 +385,13 @@ func (controller *AdminController) InstanceSettingsPublic(ctx shared.Context) er
 	if err != nil {
 		return ctx.JSON(200, dtos.InstanceSettingsDTO{})
 	}
-	allGitlabOAuthConfigs := []dtos.GitlabOauth2ConfigDTO{}
+
+	gitlabOAuthConfigs := make([]dtos.GitlabOauth2ConfigDTO, 0, len(controller.gitlabOAuth2))
 	for _, config := range controller.gitlabOAuth2 {
-		allGitlabOAuthConfigs = append(allGitlabOAuthConfigs, dtos.GitlabOauth2ConfigDTO{ProviderID: config.ProviderID, GitlabBaseURL: config.GitlabBaseURL})
+		gitlabOAuthConfigs = append(gitlabOAuthConfigs, dtos.GitlabOauth2ConfigDTO{ProviderID: config.ProviderID, GitlabBaseURL: config.GitlabBaseURL})
 	}
-	allGitlabOAuthConfigs = append(allGitlabOAuthConfigs, dtos.GitlabOauth2ConfigDTO{ProviderID: "gitlab", GitlabBaseURL: "http://localhost/test"})
-	return ctx.JSON(200, dtos.InstanceSettingsDTO{
-		SingleOrganizationMode:  settings.SingleOrganizationMode,
-		BearerTokenAuthDisabled: settings.BearerTokenAuthDisabled,
-		GitlabOAuth2Config:      allGitlabOAuthConfigs,
-	})
+
+	return ctx.JSON(200, transformer.InstanceSettingsToDTO(settings, gitlabOAuthConfigs))
 }
 
 // checkCooldown reads the config DB for the last trigger time and returns an

--- a/controllers/admin_controller.go
+++ b/controllers/admin_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gosimple/slug"
 	"github.com/l3montree-dev/devguard/database/models"
 	"github.com/l3montree-dev/devguard/dtos"
+	"github.com/l3montree-dev/devguard/integrations/gitlabint"
 	"github.com/l3montree-dev/devguard/monitoring"
 	"github.com/l3montree-dev/devguard/shared"
 	"github.com/l3montree-dev/devguard/utils"
@@ -53,6 +54,8 @@ type AdminController struct {
 
 	daemonRunner  shared.DaemonRunner
 	configService shared.ConfigService
+
+	gitlabOAuth2 map[string]*gitlabint.GitlabOauth2Config
 }
 
 func NewAdminController(
@@ -62,6 +65,7 @@ func NewAdminController(
 	statisticsService shared.StatisticsService,
 	assetService shared.AssetService,
 	configService shared.ConfigService,
+	gitlabOAuth2 map[string]*gitlabint.GitlabOauth2Config,
 ) *AdminController {
 	return &AdminController{
 		daemonRunner:      daemonRunner,
@@ -378,9 +382,18 @@ func (controller *AdminController) GetInstanceSettings(ctx shared.Context) error
 func (controller *AdminController) InstanceSettingsPublic(ctx shared.Context) error {
 	settings, err := controller.configService.GetInstanceSettings(ctx.Request().Context())
 	if err != nil {
-		return ctx.JSON(200, shared.InstanceSettings{})
+		return ctx.JSON(200, dtos.InstanceSettingsDTO{})
 	}
-	return ctx.JSON(200, settings)
+	allGitlabOAuthConfigs := []dtos.GitlabOauth2ConfigDTO{}
+	for _, config := range controller.gitlabOAuth2 {
+		allGitlabOAuthConfigs = append(allGitlabOAuthConfigs, dtos.GitlabOauth2ConfigDTO{ProviderID: config.ProviderID, GitlabBaseURL: config.GitlabBaseURL})
+	}
+	allGitlabOAuthConfigs = append(allGitlabOAuthConfigs, dtos.GitlabOauth2ConfigDTO{ProviderID: "gitlab", GitlabBaseURL: "http://localhost/test"})
+	return ctx.JSON(200, dtos.InstanceSettingsDTO{
+		SingleOrganizationMode:  settings.SingleOrganizationMode,
+		BearerTokenAuthDisabled: settings.BearerTokenAuthDisabled,
+		GitlabOAuth2Config:      allGitlabOAuthConfigs,
+	})
 }
 
 // checkCooldown reads the config DB for the last trigger time and returns an

--- a/controllers/admin_controller_test.go
+++ b/controllers/admin_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/l3montree-dev/devguard/integrations/gitlabint"
 	"github.com/l3montree-dev/devguard/mocks"
 	"github.com/l3montree-dev/devguard/shared"
 	"github.com/labstack/echo/v4"
@@ -60,6 +61,7 @@ type adminTestDeps struct {
 	statisticsService *mocks.StatisticsService
 	assetService      *mocks.AssetService
 	configService     *mocks.ConfigService
+	gitlabOAuth2      map[string]*gitlabint.GitlabOauth2Config
 }
 
 // newAdminController constructs an AdminController with the test dependencies.
@@ -71,6 +73,7 @@ func newAdminController(d adminTestDeps) *AdminController {
 		d.statisticsService,
 		d.assetService,
 		d.configService,
+		d.gitlabOAuth2,
 	)
 }
 

--- a/dtos/gitlab_oauth2_config_dto.go
+++ b/dtos/gitlab_oauth2_config_dto.go
@@ -1,0 +1,6 @@
+package dtos
+
+type GitlabOauth2ConfigDTO struct {
+	ProviderID    string `json:"providerID"`
+	GitlabBaseURL string `json:"gitlabBaseURL"`
+}

--- a/dtos/instance_setting_dto.go
+++ b/dtos/instance_setting_dto.go
@@ -1,0 +1,7 @@
+package dtos
+
+type InstanceSettingsDTO struct {
+	SingleOrganizationMode  bool                    `json:"singleOrganizationMode"`
+	BearerTokenAuthDisabled bool                    `json:"bearerTokenAuthDisabled"`
+	GitlabOAuth2Config      []GitlabOauth2ConfigDTO `json:"gitlabOAuth2Config"`
+}

--- a/transformer/instance_settings_transformer.go
+++ b/transformer/instance_settings_transformer.go
@@ -1,0 +1,14 @@
+package transformer
+
+import (
+	"github.com/l3montree-dev/devguard/dtos"
+	"github.com/l3montree-dev/devguard/shared"
+)
+
+func InstanceSettingsToDTO(settings shared.InstanceSettings, gitlabOAuthConfigs []dtos.GitlabOauth2ConfigDTO) dtos.InstanceSettingsDTO {
+	return dtos.InstanceSettingsDTO{
+		SingleOrganizationMode:  settings.SingleOrganizationMode,
+		BearerTokenAuthDisabled: settings.BearerTokenAuthDisabled,
+		GitlabOAuth2Config:      gitlabOAuthConfigs,
+	}
+}


### PR DESCRIPTION
Added that the instance-settings endpoint also returns information about the gitlaboauth2 configs.

This is in accordance with https://github.com/l3montree-dev/devguard-web/pull/914